### PR TITLE
Update video generation to use Drake's VideoWriter instead of Meshcat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ plots/*
 # SLURM
 slurm-*
 
+# startup scripts
+examples/startup_*
+
 # Sphinx
 docsrc/source/dair_pll.*
 docsrc/source/modules.rst
@@ -21,6 +24,7 @@ docs/*
 
 # virtualenv
 *sv2_env*
+*pll_env*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -91,6 +95,9 @@ instance/
 
 # Scrapy stuff:
 .scrapy
+
+# special Drake version:
+drake-dev*.deb
 
 # Sphinx documentation
 docs/_build/

--- a/dair_pll/drake_system.py
+++ b/dair_pll/drake_system.py
@@ -35,7 +35,7 @@ class DrakeSystem(System):
     def __init__(self,
                  urdfs: Dict[str, str],
                  dt: float,
-                 enable_visualizer=False) -> None:
+                 enable_visualizer: bool = False) -> None:
         """Inits ``DrakeSystem`` with provided model URDFs.
 
         Args:

--- a/dair_pll/drake_utils.py
+++ b/dair_pll/drake_utils.py
@@ -24,7 +24,6 @@ from typing import Tuple, Dict, List, Optional, Mapping, cast, Union, Type
 import numpy as np
 import os
 import os.path as op
-import pdb
 
 from pydrake.autodiffutils import AutoDiffXd  # type: ignore
 from pydrake.geometry import HalfSpace, SceneGraph  # type: ignore
@@ -58,9 +57,8 @@ CAM_FOV = np.pi/5
 VIDEO_PIXELS = [480, 640]
 FPS = 30
 SENSOR_POSE = RigidTransform(RollPitchYaw([-np.pi/2, 0, np.pi/2]), [1, 0, 0.2])
-EXP_NAME = os.environ['PLL_EXPERIMENT']
-VIDEO_FILENAME = op.join(file_utils.temp_dir(
-                    op.join(file_utils.RESULTS_DIR, EXP_NAME)), 'output.gif')
+EXP_NAME = file_utils.EXP_NAME
+VIDEO_FILENAME = file_utils.VIDEO_FILENAME
 
 DrakeTemplateType = Mapping[Type, Type]
 MultibodyPlant_ = cast(DrakeTemplateType, MultibodyPlant_)

--- a/dair_pll/drake_utils.py
+++ b/dair_pll/drake_utils.py
@@ -52,6 +52,8 @@ DRAKE_FRICTION_PROPERTY = 'coulomb_friction'
 N_DRAKE_FLOATING_BODY_VELOCITIES = 6
 DEFAULT_DT = 1e-3
 
+GROUND_COLOR = np.array([0.5, 0.5, 0.5, 0.1])
+
 CAM_FOV = np.pi/5
 VIDEO_PIXELS = [480, 640]
 FPS = 30
@@ -265,6 +267,9 @@ class MultibodyPlantDiagram:
         plant.RegisterCollisionGeometry(plant.world_body(), halfspace_transform,
                                         HalfSpace(), WORLD_GROUND_PLANE_NAME,
                                         friction)
+        plant.RegisterVisualGeometry(plant.world_body(), halfspace_transform,
+                                     HalfSpace(), WORLD_GROUND_PLANE_NAME,
+                                     GROUND_COLOR)
 
         # get collision candidates before default context filters for proximity.
         self.collision_geometry_set = get_collision_geometry_set(

--- a/dair_pll/experiment.py
+++ b/dair_pll/experiment.py
@@ -102,8 +102,6 @@ class SupervisedLearningExperimentConfig:
     """How many epochs should pass between full evaluations."""
     full_evaluation_samples: int = 5
     """How many trajectories to save in full for experiment's summary."""
-    gen_videos: bool = False
-    """Whether to use ``VideoWriter`` to generate toss videos."""
 
 
 #:

--- a/dair_pll/experiment.py
+++ b/dair_pll/experiment.py
@@ -102,6 +102,8 @@ class SupervisedLearningExperimentConfig:
     """How many epochs should pass between full evaluations."""
     full_evaluation_samples: int = 5
     """How many trajectories to save in full for experiment's summary."""
+    gen_videos: bool = False
+    """Whether to use ``VideoWriter`` to generate toss videos."""
 
 
 #:

--- a/dair_pll/file_utils.py
+++ b/dair_pll/file_utils.py
@@ -273,6 +273,7 @@ def sweep_summary_file(storage_name: str,
 
 
 # Some hard-coded video-related parameters.
+# TODO Can build in a more elegant solution in the future.
 EXP_NAME = os.environ['PLL_EXPERIMENT']
 VIDEO_FILENAME = path.join(temp_dir(path.join(RESULTS_DIR, EXP_NAME)),
                            'output.gif')

--- a/dair_pll/file_utils.py
+++ b/dair_pll/file_utils.py
@@ -269,3 +269,10 @@ def sweep_summary_file(storage_name: str,
     if n_run is None:
         return append_by_extension(directory, STATS_EXTENSION)
     return path.join(directory, str(n_run) + STATS_EXTENSION)
+
+
+
+# Some hard-coded video-related parameters.
+EXP_NAME = os.environ['PLL_EXPERIMENT']
+VIDEO_FILENAME = path.join(temp_dir(path.join(RESULTS_DIR, EXP_NAME)),
+                           'output.gif')

--- a/dair_pll/multibody_learnable_system.py
+++ b/dair_pll/multibody_learnable_system.py
@@ -30,7 +30,7 @@ from sappy import SAPSolver  # type: ignore
 from torch import Tensor
 
 from dair_pll import file_utils
-from dair_pll import meshcat_utils
+from dair_pll import vis_utils
 from dair_pll import urdf_utils
 from dair_pll.drake_system import DrakeSystem
 from dair_pll.experiment import LEARNED_SYSTEM_NAME, \
@@ -108,7 +108,7 @@ class MultibodyLearnableSystem(System):
         e.g. data.
 
         Implemented as a thin wrapper of
-        ``meshcat_utils.generate_visualization_system()``, which generates a
+        ``vis_utils.generate_visualization_system()``, which generates a
         drake system where each model in the ``MultibodyLearnableSystem`` has a
         duplicate, and visualization elements are repainted for visual
         distinction.
@@ -118,7 +118,7 @@ class MultibodyLearnableSystem(System):
         """
         if not self.visualization_system:
             self.visualization_system = \
-                meshcat_utils.generate_visualization_system(
+                vis_utils.generate_visualization_system(
                     DrakeSystem(self.urdfs, self.dt)
                 )
 
@@ -129,7 +129,7 @@ class MultibodyLearnableSystem(System):
         """Visualizes a comparison between a target trajectory and one
         predicted by this system.
 
-        Implemented as a wrapper to ``meshcat_utils.visualize_trajectory()``.
+        Implemented as a wrapper to ``vis_utils.visualize_trajectory()``.
 
         Args:
             target_trajectory: (T, space.n_x) trajectory to compare to.
@@ -146,7 +146,7 @@ class MultibodyLearnableSystem(System):
         visualization_trajectory = torch.cat(
             (space.q(target_trajectory), space.q(prediction_trajectory),
              space.v(target_trajectory), space.v(prediction_trajectory)), -1)
-        return meshcat_utils.visualize_trajectory(
+        return vis_utils.visualize_trajectory(
             self.get_visualization_system(), visualization_trajectory)
 
     def contactnets_loss(self,

--- a/dair_pll/vis_utils.py
+++ b/dair_pll/vis_utils.py
@@ -79,13 +79,13 @@ def generate_visualization_system(
         for body_index in plant.GetBodyIndices(model_id):
             body_frame = plant.GetBodyFrameIdOrThrow(body_index)
             for geometry_id in inspector.GetGeometries(body_frame,
-                                                       Role.kIllustration):
+                                                       Role.kPerception):
                 props = inspector.GetPerceptionProperties(geometry_id)
                 # phong.diffuse is the name of property controlling perception
                 # color.
                 if props and \
                    props.HasProperty(PERCEPTION_COLOR_GROUP, \
-                                         PERCEPTION_COLOR_PROPERTY):
+                                     PERCEPTION_COLOR_PROPERTY):
                     # Sets color in properties.
                     props.UpdateProperty(
                         PERCEPTION_COLOR_GROUP, PERCEPTION_COLOR_PROPERTY,

--- a/dair_pll/vis_utils.py
+++ b/dair_pll/vis_utils.py
@@ -79,7 +79,7 @@ def generate_visualization_system(
         for body_index in plant.GetBodyIndices(model_id):
             body_frame = plant.GetBodyFrameIdOrThrow(body_index)
             for geometry_id in inspector.GetGeometries(body_frame,
-                                                       Role.kIllustration):
+                                                       Role.kPerception):
                 props = inspector.GetPerceptionProperties(geometry_id)
                 # phong.diffuse is the name of property controlling perception
                 # color.

--- a/dair_pll/vis_utils.py
+++ b/dair_pll/vis_utils.py
@@ -1,45 +1,40 @@
-"""Utility functions for visualizing trajectories with meshcat.
+"""Utility functions for visualizing trajectories.
 
-Visualization of Drake systems is managed by meshcat. This allows for a
-relatively thin implementation of visualization for very complex geometries.
+Visualization of Drake systems can be done with Drake's VideoWriter. This allows
+for a relatively thin implementation of visualization for very complex
+geometries.
 
 The main contents of this file are as follows:
 
     * A method to generate a dummy ``DrakeSystem`` which simultaneously
       visualizes two trajectories of the same system.
-    * A method which takes a ``DrakeSystem`` and corresponding
-      trajectory, captures a visualization video, and outputs it as a numpy
-      ndarray.
-
-Meshcat visualization must be externally set up with the following steps:
-
-    * Run ``meshcat-server``, which will put up a meshcat server at the
-      default address.
-    * Open the visualizer ``assets/static.html`` in a browser.
-
-Occasionally, the visualization step may block indefinitely. This is usually
-caused by the visualizer browser window loosing connect to the server,
-and can be fixed by refreshing the browser page.
+    * A method which takes a ``DrakeSystem`` and corresponding trajectory,
+      captures a visualization video, and outputs it as a numpy ndarray.
 """
 from copy import deepcopy
 from typing import Tuple
 
-import meshcat  # type: ignore
 import numpy as np
+import time
+import pdb
+
 from pydrake.geometry import Role, RoleAssign, Rgba  # type: ignore
 from pydrake.math import RigidTransform  # type: ignore
+from pydrake.visualization import VideoWriter  # type: ignore
+
 from torch import Tensor
+from PIL import Image
 
 from dair_pll.drake_system import DrakeSystem
+from dair_pll import file_utils
 
-CAM_FOV = np.pi / 3
 RESOLUTION = [640, 480]
 RED = Rgba(0.6, 0.0, 0.0, 0.7)
 BLUE = Rgba(0.0, 0.0, 0.6, 0.7)
 BASE_SYSTEM_DEFAULT_COLOR = RED
 LEARNED_SYSTEM_DEFAULT_COLOR = BLUE
-ILLUSTRATION_COLOR_GROUP = 'phong'
-ILLUSTRATION_COLOR_PROPERTY = 'diffuse'
+PERCEPTION_COLOR_GROUP = 'phong'
+PERCEPTION_COLOR_PROPERTY = 'diffuse'
 LEARNED_TAG = '__learned__'
 
 
@@ -72,10 +67,12 @@ def generate_visualization_system(
                                        base_system.dt,
                                        enable_visualizer=True)
 
-    # Recolors every illustration geometry to default colors
+    # Recolors every perception geometry to default colors
     plant_diagram = visualization_system.plant_diagram
     plant = plant_diagram.plant
     scene_graph = plant_diagram.scene_graph
+    scene_graph_context = scene_graph.GetMyContextFromRoot(
+                            plant_diagram.sim.get_mutable_context())
     inspector = scene_graph.model_inspector()
     for model_id in plant_diagram.model_ids:
         model_name = plant.GetModelInstanceName(model_id)
@@ -83,27 +80,27 @@ def generate_visualization_system(
             body_frame = plant.GetBodyFrameIdOrThrow(body_index)
             for geometry_id in inspector.GetGeometries(body_frame,
                                                        Role.kIllustration):
-                props = inspector.GetIllustrationProperties(geometry_id)
-                # phong.diffuse is the name of property controlling
-                # illustration color.
-                if props and props.HasProperty(ILLUSTRATION_COLOR_GROUP,
-                                               ILLUSTRATION_COLOR_PROPERTY):
+                props = inspector.GetPerceptionProperties(geometry_id)
+                # phong.diffuse is the name of property controlling perception
+                # color.
+                if props and \
+                   props.HasProperty(PERCEPTION_COLOR_GROUP, \
+                                         PERCEPTION_COLOR_PROPERTY):
                     # Sets color in properties.
                     props.UpdateProperty(
-                        ILLUSTRATION_COLOR_GROUP, ILLUSTRATION_COLOR_PROPERTY,
+                        PERCEPTION_COLOR_GROUP, PERCEPTION_COLOR_PROPERTY,
                         learned_system_color
                         if LEARNED_TAG in model_name else base_system_color)
                     # Tells ``scene_graph`` to update the color.
-                    scene_graph.AssignRole(plant.get_source_id(), geometry_id,
-                                           props, RoleAssign.kReplace)
+                    scene_graph.RemoveRole(scene_graph_context,
+                                           plant.get_source_id(), geometry_id,
+                                           Role.kPerception)
+                    scene_graph.AssignRole(scene_graph_context,
+                                           plant.get_source_id(), geometry_id,
+                                           props, RoleAssign.kNew)
 
-    # Changing illustration properties requires the ``SceneGraph`` to have
-    # its context reset in order. For these  changes to then be loaded by the
-    # ``MeshcatVisualizer``, the ``Simulator`` must then be re-initialized to
-    # trigger ``MeshcatVisualizer.load()``.
-    scene_graph.SetDefaultContext(
-        scene_graph.GetMyContextFromRoot(
-            plant_diagram.sim.get_mutable_context()))
+    # Changing perception properties requires the ``Simulator`` to be
+    # re-initialized.
     plant_diagram.sim.Initialize()
 
     return visualization_system
@@ -111,7 +108,8 @@ def generate_visualization_system(
 
 def visualize_trajectory(drake_system: DrakeSystem,
                          x_trajectory: Tensor,
-                         framerate: int = 30) -> Tuple[np.ndarray, int]:
+                         framerate: int = 30
+) -> Tuple[np.ndarray, int]:
     """Visualizes trajectory of system.
 
     Specifies a ``framerate`` for output video, though should be noted that
@@ -121,10 +119,6 @@ def visualize_trajectory(drake_system: DrakeSystem,
 
         max(round(60/11), 1) == 5.
 
-    Code mostly sourced from Greg Izatt (@gizatt) in this Gist::
-
-        https://gist.github.com/gizatt/d96e6b0bcbe6c7ec331efad53a6f11bc
-
     Args:
         drake_system: System associated with provided trajectory.
         x_trajectory: (T, drake_system.space.n_x) state trajectory.
@@ -132,42 +126,46 @@ def visualize_trajectory(drake_system: DrakeSystem,
 
     Returns:
         (1, T, 3, H, W) ndarray video capture of trajectory with resolution
-        H x W, approximately 640 x 480.
-        The true framerate, rounded to an integer
+        H x W, which are set to 480x640 in :py:mod:`dair_pll.drake_utils`.
+        The true framerate, rounded to an integer.
     """
     assert drake_system.plant_diagram.visualizer is not None
     assert x_trajectory.dim() == 2
 
-    # downsample trajectory to approximate framerate.
+    vis = drake_system.plant_diagram.visualizer
+    sim = drake_system.plant_diagram.sim
+
+    # Downsample trajectory to approximate framerate.
     temporal_downsample = max(round((1 / drake_system.dt) / framerate), 1)
     actual_framerate = round((1 / drake_system.dt) / temporal_downsample)
     x_trajectory = x_trajectory[::temporal_downsample, :]
 
-    # Set camera to look at origin from specified point ``camera_position``
-    camera_position = np.array([0., 20., 5.])
-    meshcat_visualizer = drake_system.plant_diagram.visualizer.vis
-    meshcat_visualizer["/Cameras/default/rotated"].set_object(
-        meshcat.geometry.PerspectiveCamera(fov=CAM_FOV, zoom=0.4))
-    meshcat_visualizer['/Cameras/default'].set_transform(
-        RigidTransform(p=camera_position).GetAsMatrix4())
-
-    # Not sure if this part is necessary
-    meshcat_visualizer['/Cameras/default/rotated/<object>'].set_property(
-        'position', [0, 0, 0])
-
-    # Capture frames
-    frames = []
+    # Simulate the system according to the provided data.
     _, carry = drake_system.sample_initial_condition()
     for x_current in x_trajectory:
         drake_system.preprocess_initial_condition(x_current.unsqueeze(0), carry)
-        frame = meshcat_visualizer.get_image()
-        frames.append(frame)
 
-    # composes video ndarray of shape (T, H, W, 4[rgba])
-    video = np.stack([np.array(frame) for frame in frames])
+        # Force publish video frame.
+        sim_context = sim.get_mutable_context()
+        video_context = vis.GetMyContextFromRoot(sim_context)
+        vis._publish(video_context)
 
-    # remove alpha channel, downsample, and reorder axes to output type
+    # Compose a video ndarray of shape (T, H, W, 4[rgba]).
+    video = np.stack([np.asarray(frame) for frame in vis._pil_images])
+    vis.Save()
+
+    # Since Drake's VideoWriter defaults to not looping gifs, re-load and re-
+    # save the gif to ensure it loops.  This gif is only for debugging purposes,
+    # as the gif gets overwritten with every trajectory.  The actual output of
+    # this function is a numpy array.
+    im = Image.open(vis._filename)
+    new_name = vis._filename.split('.')[0] + '_.gif'
+    im.save(new_name, save_all=True, loop=0)
+    im.close()
+
+    # Remove alpha channel and reorder axes to output type.
+    height = video.shape[1]
     video = np.expand_dims(np.moveaxis(video, 3, 1), 0)
-    resolution_downsample = max(frames[0].size[0] // RESOLUTION[0], 1)
-    video = video[:, :, :3, 0::resolution_downsample, 0::resolution_downsample]
+    video = video[:, :, :3, :, :]
     return video, actual_framerate
+

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_reqs = [
     'numpy',
     'scipy==1.7.3',
     'typing_extensions',
-    'meshcat',
     'matplotlib',
     'threadpoolctl',
     'click',


### PR DESCRIPTION
With some Drake changes, our video rollout generation using Meshcat had broken.  These changes switch to the newer Drake VideoWriter.  The generated rollout video is created via the same inputs (a `DrakeSystem`, a pytorch tensor of a trajectory, and a frame rate) and returns the same outputs (a `(1, T, 3, H, W)` numpy array of an RGB frame per time step, and a true frame rate).

One of the Drake functions used by this fix is an overloaded version of `SceneGraph.RemoveRole`, functionality which [first made it into the Drake nightly release on January 24th, 2023](https://github.com/RobotLocomotion/drake/pull/18645) -- again, as of the time of making this PR, this change requires Drake functionality that is not yet in the stable Drake release.

Some nice-to-haves that are not yet implemented include:
- [x] Show the ground in the generated videos.  Currently everything is just the background color, so the only sense of the table is from the ground truth system.

An example of a generated toss video using these updates:
![output_](https://user-images.githubusercontent.com/29261567/214459733-f3352c33-adc4-4186-a218-95172f3dec98.gif)
