### PR TITLE
Export learned friction in URDFs

### DIFF
--- a/assets/contactnets_cube.urdf
+++ b/assets/contactnets_cube.urdf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="cube">
+<robot name="cube" xmlns:drake="https://drake.mit.edu/">
     <link name="body">
         <inertial>
             <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/assets/contactnets_elbow.urdf
+++ b/assets/contactnets_elbow.urdf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="elbow">
+<robot name="elbow" xmlns:drake="https://drake.mit.edu/">
     <link name="elbow_1">
         <inertial>
             <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/assets/contactnets_elbow_mesh.urdf
+++ b/assets/contactnets_elbow_mesh.urdf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="elbow">
+<robot name="elbow" xmlns:drake="https://drake.mit.edu/">
     <link name="elbow_1">
         <inertial>
             <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/dair_pll/urdf_utils.py
+++ b/dair_pll/urdf_utils.py
@@ -27,6 +27,7 @@ _ORIGIN = "origin"
 _MASS = "mass"
 _INERTIA = "inertia"
 _INERTIAL = "inertial"
+_VISUAL = "visual"
 _COLLISION = "collision"
 _GEOMETRY = "geometry"
 _BOX = "box"
@@ -63,6 +64,7 @@ _URDF_DEFAULT_TREE: Dict[str, List] = {
     _INERTIA: [],
     _INERTIAL: [_ORIGIN, _MASS, _INERTIA],
     _GEOMETRY: [],
+    _VISUAL: [_GEOMETRY, _ORIGIN],
     _COLLISION: [_GEOMETRY, _ORIGIN],
     _BOX: [],
     _SPHERE: [],
@@ -92,6 +94,7 @@ _URDF_DEFAULT_ATTRIBUTES: Dict[str, Dict] = {
         _LENGTH: _ZERO_FLOAT
     },
     _GEOMETRY: {},
+    _VISUAL: {},
     _COLLISION: {}
 }
 """Default element attributes for URDFs.
@@ -277,16 +280,19 @@ def fill_link_with_parameterization(element: ElementTree.Element, pi_cm: Tensor,
     body_inertia_element.attrib = dict(zip(_INERTIAL_ATTRIBUTES, I_BBcm_B))
 
     for geometry in geometries:
-        collision_element = \
-            UrdfFindOrDefault.find(element, _COLLISION)
-        geometry_element = \
-            UrdfFindOrDefault.find(collision_element,
-                                   _GEOMETRY)
+        collision_element = UrdfFindOrDefault.find(element, _COLLISION)
+        visual_element = UrdfFindOrDefault.find(element, _VISUAL)
+        geometry_elements = [
+            UrdfFindOrDefault.find(collision_element, _GEOMETRY),
+            UrdfFindOrDefault.find(visual_element, _GEOMETRY)
+        ]
+        
         (shape_tag, shape_attributes) = \
             UrdfGeometryRepresentationFactory.representation(geometry,
                                                              output_dir)
-        shape_element = UrdfFindOrDefault.find(geometry_element, shape_tag)
-        shape_element.attrib = shape_attributes
+        for geometry_element in geometry_elements:
+            shape_element = UrdfFindOrDefault.find(geometry_element, shape_tag)
+            shape_element.attrib = shape_attributes
 
 
 def represent_multibody_terms_as_urdfs(multibody_terms: MultibodyTerms,

--- a/dair_pll/urdf_utils.py
+++ b/dair_pll/urdf_utils.py
@@ -256,7 +256,7 @@ class UrdfGeometryRepresentationFactory:
 
 def fill_link_with_parameterization(element: ElementTree.Element, pi_cm: Tensor,
                                     geometries: List[CollisionGeometry],
-                                    frictions: Tensor,
+                                    friction_coeffs: Tensor,
                                     output_dir: str) -> None:
     """Convert pytorch inertial and geometric representations to URDF elements.
 
@@ -265,8 +265,8 @@ def fill_link_with_parameterization(element: ElementTree.Element, pi_cm: Tensor,
         pi_cm: (10,) inertial representation of link in ``pi_cm``
                 parameterization.
         geometries: All geometries attached to body.
-        frictions: All friction coefficients associated with each geometry.  The
-          ``Tensor`` will be of shape ``(len(geometries),)``.
+        friction_coeffs: All friction coefficients associated with each
+          geometry.  The ``Tensor`` will be of shape ``(len(geometries),)``.
         output_dir: File directory to store helper files (e.g., meshes).
 
     Warning:
@@ -283,7 +283,7 @@ def fill_link_with_parameterization(element: ElementTree.Element, pi_cm: Tensor,
         InertialParameterConverter.pi_cm_to_urdf(pi_cm)
 
     # This will have to change when function can handle more than one geometry.
-    mu = str(frictions.item())
+    mu = str(friction_coeffs.item())
 
     body_inertial_element = UrdfFindOrDefault.find(element, _INERTIAL)
 
@@ -367,12 +367,13 @@ def represent_multibody_terms_as_urdfs(multibody_terms: MultibodyTerms,
                          multibody_terms.contact_terms.geometries[index])
                     for index in body_geometry_indices
                 ]
-                body_frictions = \
+                body_friction_coeffs = \
                     multibody_terms.contact_terms.friction_coefficients[
                         body_geometry_indices
                     ]
                 fill_link_with_parameterization(element, pi_cm[body_index, :],
-                                                body_geometries, body_frictions,
+                                                body_geometries,
+                                                body_friction_coeffs,
                                                 output_dir)
 
         register_namespace('drake', _DRAKE_URL)

--- a/dair_pll/urdf_utils.py
+++ b/dair_pll/urdf_utils.py
@@ -34,11 +34,11 @@ _BOX = "box"
 _SPHERE = "sphere"
 _CYLINDER = "cylinder"
 _MESH = "mesh"
-_DRAKE = "{https://drake.mit.edu/}"
+_DRAKE_URL = "https://drake.mit.edu/"
 _PROXIMITY_PROPERTIES = "proximity_properties"
-_DRAKE_PROXIMITY_PROPERTIES = _DRAKE + _PROXIMITY_PROPERTIES
+_DRAKE_PROXIMITY_PROPERTIES = '{' + _DRAKE_URL + '}' + _PROXIMITY_PROPERTIES
 _FRICTION = "mu_static"
-_DRAKE_FRICTION = _DRAKE + _FRICTION
+_DRAKE_FRICTION = '{' + _DRAKE_URL + '}' + _FRICTION
 
 # attributes
 _VALUE = "value"
@@ -375,7 +375,7 @@ def represent_multibody_terms_as_urdfs(multibody_terms: MultibodyTerms,
                                                 body_geometries, body_frictions,
                                                 output_dir)
 
-        register_namespace('drake', 'https://drake.mit.edu/')
+        register_namespace('drake', _DRAKE_URL)
         system_urdf_representation = ElementTree.tostring(
             urdf_tree.getroot(), encoding="utf-8").decode("utf-8")
         urdf_xml[

--- a/dair_pll/urdf_utils.py
+++ b/dair_pll/urdf_utils.py
@@ -37,8 +37,8 @@ _MESH = "mesh"
 _DRAKE_URL = "https://drake.mit.edu/"
 _PROXIMITY_PROPERTIES = "proximity_properties"
 _DRAKE_PROXIMITY_PROPERTIES = '{' + _DRAKE_URL + '}' + _PROXIMITY_PROPERTIES
-_FRICTION = "mu_static"
-_DRAKE_FRICTION = '{' + _DRAKE_URL + '}' + _FRICTION
+_MU_STATIC = "mu_static"
+_DRAKE_MU_STATIC = '{' + _DRAKE_URL + '}' + _MU_STATIC
 
 # attributes
 _VALUE = "value"
@@ -69,8 +69,8 @@ _URDF_DEFAULT_TREE: Dict[str, List] = {
     _INERTIA: [],
     _INERTIAL: [_ORIGIN, _MASS, _INERTIA],
     _GEOMETRY: [],
-    _DRAKE_FRICTION: [],
-    _DRAKE_PROXIMITY_PROPERTIES: [_DRAKE_FRICTION],
+    _DRAKE_MU_STATIC: [],
+    _DRAKE_PROXIMITY_PROPERTIES: [_DRAKE_MU_STATIC],
     _VISUAL: [_GEOMETRY, _ORIGIN],
     _COLLISION: [_GEOMETRY, _ORIGIN, _DRAKE_PROXIMITY_PROPERTIES],
     _BOX: [],
@@ -104,7 +104,7 @@ _URDF_DEFAULT_ATTRIBUTES: Dict[str, Dict] = {
     _VISUAL: {},
     _COLLISION: {},
     _DRAKE_PROXIMITY_PROPERTIES: {},
-    _DRAKE_FRICTION: _SCALAR_ATTR
+    _DRAKE_MU_STATIC: _SCALAR_ATTR
 }
 """Default element attributes for URDFs.
 
@@ -311,7 +311,7 @@ def fill_link_with_parameterization(element: ElementTree.Element, pi_cm: Tensor,
 
         prox_props_element = UrdfFindOrDefault.find(collision_element,
             _DRAKE_PROXIMITY_PROPERTIES)
-        UrdfFindOrDefault.find(prox_props_element, _DRAKE_FRICTION).set(
+        UrdfFindOrDefault.find(prox_props_element, _DRAKE_MU_STATIC).set(
             _VALUE, mu)
 
 


### PR DESCRIPTION
Presently, any exported URDFs with learned parameters feature the learned geometries and learned inertial properties, though the friction parameters remain unchanged from their initializations at the start of training.  This PR adds the functionality required to export learned friction parameters as well.

Additional minor changes also wrapped into this PR:
- Exported URDFs now feature the learned geometry in both the `<collision>` and `<visual>` tags.  Before, learned geometry only edited the `<collision>` tags.
- Include the Drake xml namespace definition in all of the example URDF files in the `assets` directory.  Without this, use of those URDFs threw an error because the `<drake:proximity_properties>` and `<drake:mu_static>` tags could not be parsed.