### PR TITLE
Enforce learned box and sphere lengths to be positive

### DIFF
--- a/dair_pll/urdf_utils.py
+++ b/dair_pll/urdf_utils.py
@@ -230,14 +230,15 @@ class UrdfGeometryRepresentationFactory:
     @staticmethod
     def box_representation(box: Box) -> Tuple[str, Dict[str, str]]:
         """Returns URDF representation as ``box`` tag with full-length sizes."""
-        size = ' '.join([str(2 * i.item()) for i in box.half_lengths.view(-1)])
+        size = ' '.join([str(2 * i.item()) for i in \
+                         box.get_half_lengths().view(-1)])
         return _BOX, {_SIZE: size}
 
     @staticmethod
     def sphere_representation(sphere: Sphere) -> Tuple[str, Dict[str, str]]:
         """Returns URDF representation as ``sphere`` tag with radius
         attribute."""
-        return _SPHERE, {_RADIUS: str(sphere.radius.item())}
+        return _SPHERE, {_RADIUS: str(sphere.get_radius().item())}
 
     @staticmethod
     def mesh_representation(convex: DeepSupportConvex, output_dir: str) -> \


### PR DESCRIPTION
When learning lengths of `Box` geometries, the learned lengths could (and often did) go negative.  It appears the same could happen with `Sphere` geometries as well.  This PR remedies this issue by distinguishing the learned parameters (which can take gradient steps during the learning process) from the geometric quantities (which are used for exporting URDF files and later for simulation).  Specifically, the learned parameters are free to reside in `(-\infty, \infty)`, then the geometric quantities are calculated as the absolute value of those learned parameters.