### PR TITLE
Eliminate extraneous initial frame from rollout videos

### DIFF
--- a/dair_pll/vis_utils.py
+++ b/dair_pll/vis_utils.py
@@ -139,6 +139,10 @@ def visualize_trajectory(drake_system: DrakeSystem,
     actual_framerate = round((1 / drake_system.dt) / temporal_downsample)
     x_trajectory = x_trajectory[::temporal_downsample, :]
 
+    # Clear the images before iterating through the trajectory (by default the
+    # video starts with one image of the systems at the origin).
+    vis._pil_images = []
+
     # Simulate the system according to the provided data.
     _, carry = drake_system.sample_initial_condition()
     for x_current in x_trajectory:


### PR DESCRIPTION
Very minor change to video generation via Drake `VideoWriter` as implemented in #3 to improve the quality of the generated rollout videos.  Here's an example of what was happening before and what this improvement does.

### Before
![output_before](https://user-images.githubusercontent.com/29261567/224432524-cefa5ec6-8c79-4500-9e1f-1da6535200ac.gif)
When a toss video was generated, the first frame features the system geometries at the origin and colorized according to the URDF -- not necessarily the colors corresponding to ground truth and learned systems.  All subsequent frames are the continuous toss trajectory.  The first frame did not belong with the rest of the generated video.

The above example features an easy-to-see bright green link at the origin for the first frame, followed by the consistently colored comparison trajectory.

### After
![output_after](https://user-images.githubusercontent.com/29261567/224432706-f8ac15a3-9a4e-4438-9f99-a167bb80773c.gif)
This extraneous first frame is eliminated.