### PR TITLE
Experiment saving and resumption

### DIFF
--- a/dair_pll/dataset_generation.py
+++ b/dair_pll/dataset_generation.py
@@ -1,0 +1,149 @@
+r""" This module also contains utilities for generating simulation data
+from a :class:`~dair_pll.system.System`\ .
+
+Centers around the :class:`ExperimentDatasetGenerator` type, which takes in a
+configuration describing trajectory parameters, as well as distributions for
+initial conditions and noise to apply to simulated states.
+"""
+from dataclasses import dataclass
+from typing import Type, Union, List
+
+import torch
+from torch import Tensor
+
+from dair_pll import file_utils
+from dair_pll.state_space import CenteredSampler, UniformSampler, \
+    GaussianWhiteNoiser, UniformWhiteNoiser
+from dair_pll.system import System
+
+
+@dataclass
+class DataGenerationConfig:
+    """:func:`~dataclasses.dataclass` for configuring generation of a
+    trajectory dataset."""
+    # pylint: disable=too-many-instance-attributes
+    dt: float = 1e-3
+    r"""Time step, ``> 0``\ ."""
+    n_pop: float = 16384
+    r"""Total number of trajectories to select from, ``>= 0``\ ."""
+    duration: int = 80
+    r"""Trajectory length, ``>= 1``\ ."""
+    x_0: Tensor = Tensor()
+    """Nominal initial states."""
+    sampler_type: Type[CenteredSampler] = UniformSampler
+    r"""Distribution for sampling around :attr:`x_0`\ ."""
+    sampler_ranges: Tensor = Tensor()
+    r"""``(2 * n_v)`` size of perturbations sampled around :attr:`x_0`\ ."""
+    noiser_type: Union[Type[GaussianWhiteNoiser], Type[UniformWhiteNoiser]] = \
+        GaussianWhiteNoiser
+    """Type of noise to add to data."""
+    static_noise: Tensor = Tensor()
+    """``(2 * n_v)`` sampler ranges for constant-in-time trajectory noise."""
+    dynamic_noise: Tensor = Tensor()
+    """``(2 * n_v)`` sampler ranges for i.i.d.-in-time trajectory noise."""
+    storage: str = './'
+    """Experiment folder for data storage. Defaults to working directory."""
+
+    def __post_init__(self):
+        """Method to check validity of parameters."""
+        assert self.dt > 0.
+        assert self.n_pop >= 0
+        assert self.duration >= 1
+        assert self.sampler_ranges.nelement() == self.static_noise.nelement()
+        assert self.static_noise.nelement() == self.dynamic_noise.nelement()
+
+
+class ExperimentDatasetGenerator:
+    r"""Conducts generation of a population of simulated trajectories from
+    a provided system.
+
+    These trajectories are stored on disk at a location described in the
+    generator's configuration. Two sets are generated: one `ground truth`
+    set, which are precisely what the system predicts; and a `learning` set
+    which has artificial measurement noise added.
+
+    The various parameters describing the qualities of the dataset are given
+    in the provided :py:class:`DataGenerationConfig`\ .
+    """
+    system: System
+    config: DataGenerationConfig
+
+    def __init__(self, system: System, config: DataGenerationConfig) -> None:
+        self.system = system
+        self.config = config
+
+    def generate(self) -> None:
+        """Simulate trajectories and write them to disk."""
+        config = self.config
+        n_pop = config.n_pop
+        ground_truth_dir = file_utils.ground_truth_data_dir(config.storage)
+        learning_dir = file_utils.learning_data_dir(config.storage)
+        n_on_disk = file_utils.get_trajectory_count(ground_truth_dir)
+        n_to_add = 30
+        while n_on_disk < n_pop:
+            n_on_disk = file_utils.get_trajectory_count(ground_truth_dir)
+            n_to_add = min(n_to_add, max(n_pop - n_on_disk, 0))
+            if n_to_add == 0:
+                break
+            ground_truth_trajectories = self.simulate_trajectory_set(n_to_add)
+            learning_trajectories = self.make_noised_trajectories(
+                ground_truth_trajectories)
+            for relative_index in range(n_to_add):
+                ground_truth_file = file_utils.trajectory_file(
+                    ground_truth_dir, n_on_disk + relative_index)
+                torch.save(ground_truth_trajectories[relative_index],
+                           ground_truth_file)
+
+                learning_file = file_utils.trajectory_file(
+                    learning_dir, n_on_disk + relative_index)
+                torch.save(learning_trajectories[relative_index], learning_file)
+
+    def simulate_trajectory_set(self, num_trajectories: int) -> List[Tensor]:
+        """Simulate trajectories using :py:attr:`system`
+
+        Args:
+            num_trajectories: number of trajectories to simulate
+
+        Returns:
+            List of ``(T, self.system.space.n_x)`` trajectories.
+        """
+        assert num_trajectories >= 0
+        config = self.config
+        system = self.system
+        starting_state = config.x_0
+        system.set_state_sampler(
+            config.sampler_type(system.space,
+                                config.sampler_ranges,
+                                x_0=starting_state))
+
+        trajectories = []
+        for _ in range(num_trajectories):
+            trajectory, _ = system.sample_trajectory(config.duration)
+            trajectories.append(trajectory)
+        return trajectories
+
+    def make_noised_trajectories(self, traj_set: List[Tensor]) -> List[Tensor]:
+        r"""Given ground-truth trajectories predicted with :py:attr:`system`\ ,
+        returns corresponding set of learning trajectories with added
+        measurement noise.
+
+        Args:
+            traj_set: List of ground-truth ``(*, self.system.space.n_x)`` state
+              trajectories.
+
+        Returns:
+            List of ``(*, self.system.space.n_x)`` noisy state trajectories.
+        """
+        config = self.config
+        noiser = config.noiser_type(self.system.space)
+        noised_trajectories = []
+        for traj in traj_set:
+            static_disturbed = noiser.noise(traj,
+                                            config.static_noise,
+                                            independent=False)
+            dynamic_disturbed = noiser.noise(static_disturbed,
+                                             config.dynamic_noise)
+            dynamic_disturbed = self.system.space.project_derivative(
+                dynamic_disturbed, config.dt)
+            noised_trajectories.append(dynamic_disturbed)
+        return noised_trajectories

--- a/dair_pll/dataset_management.py
+++ b/dair_pll/dataset_management.py
@@ -1,51 +1,39 @@
 r"""Classes for generating and managing datasets for experiments.
 
-Centers around the :class:`SystemDataManager` type, which transforms a set of
-trajectories saved to disc for various tasks encountered during an
-experiment. This module also contains utilities for generating simulation data
-from a :class:`~dair_pll.system.System`\ ."""
-import time
-from dataclasses import dataclass
-from typing import List, Tuple, Union, Type, Optional
+Centers around the :class:`ExperimentDataManager` type, which transforms a
+set of trajectories saved to disk for various tasks encountered during an
+experiment."""
+from dataclasses import dataclass, field
+from typing import List, Tuple, Optional, cast
 
 import torch
 from torch import Tensor
 from torch.utils.data import Dataset
 
 from dair_pll import file_utils
-from dair_pll.state_space import CenteredSampler, \
-    GaussianWhiteNoiser, UniformSampler, UniformWhiteNoiser
-from dair_pll.system import System
 
 
 @dataclass
-class DataGenerationConfig:
-    """:func:`~dataclasses.dataclass` for configuring generation of a
-    trajectory dataset."""
-    # pylint: disable=too-many-instance-attributes
-    n_pop: float = 16384
-    r"""Total number of trajectories to select from, ``>= 0``\ ."""
-    traj_len: int = 80
-    r"""Trajectory length, ``>= 1``\ ."""
-    x_0: Tensor = Tensor()
-    """Nominal initial states."""
-    sampler_type: Type[CenteredSampler] = UniformSampler
-    r"""Distribution for sampling around :attr:`x_0`\ ."""
-    sampler_ranges: Tensor = Tensor()
-    r"""``(2 * n_v)`` size of perturbations sampled around :attr:`x_0`\ ."""
-    noiser_type: Union[Type[GaussianWhiteNoiser], Type[UniformWhiteNoiser]] = \
-        GaussianWhiteNoiser
-    """Type of noise to add to data."""
-    static_noise: Tensor = Tensor()
-    """``(2 * n_v)`` sampler ranges for constant-in-time trajectory noise."""
-    dynamic_noise: Tensor = Tensor()
-    """``(2 * n_v)`` sampler ranges for i.i.d.-in-time trajectory noise."""
+class TrajectorySliceConfig:
+    """:func:`~dataclasses.dataclass` for configuring a trajectory slicing
+    for training process."""
+    t_skip: int = 0
+    """Index of first time to predict from ``>=`` :attr:`t_history` ``- 1``."""
+    t_history: int = 1
+    r"""Number of steps in initial condition for prediction, ``>= 1``\ ."""
+    t_prediction: int = 1
+    r"""Number of future steps to use during training/evaluation, ``>= 1``\ ."""
+
+    def __post_init__(self):
+        """Method to check validity of parameters."""
+        assert self.t_skip + 1 >= self.t_history
+        assert self.t_history >= 1
+        assert self.t_prediction >= 1
 
 
 @dataclass
 class DataConfig:
     """:func:`~dataclasses.dataclass` for configuring a trajectory dataset."""
-    # pylint: disable=too-many-instance-attributes
     dt: float = 1e-3
     r"""Time step, ``> 0``\ ."""
     train_fraction: float = 0.5
@@ -54,234 +42,224 @@ class DataConfig:
     r"""Fraction of validation trajectories to select, ``<= 1, >= 0``\ ."""
     test_fraction: float = 0.25
     r"""Fraction of testing trajectories to select, ``<= 1, >= 0``\ ."""
-    t_skip: int = 0
-    """Index of first time to predict from ``>=`` :attr:`t_history` ``- 1``."""
-    t_history: int = 1
-    r"""Number of steps in initial condition for prediction, ``>= 1``\ ."""
-    t_prediction: int = 1
-    r"""Number of future steps to use during training/evaluation, ``>= 1``\ ."""
-    generation_config: Optional[DataGenerationConfig] = None
-    """Optionally, signals generation of data from given system."""
-    import_directory: Optional[str] = None
-    """Alternatively, signals data import from separate directory."""
-    dynamic_updates_from: Optional[int] = None
-    """Alternatively, loads dynamically, but blocks on initial size set."""
+    slice_config: TrajectorySliceConfig = field(
+        default_factory=TrajectorySliceConfig)
+    update_dynamically: bool = False
+    """Whether to check for new trajectories after each epoch."""
+
+    def __post_init__(self):
+        """Method to check validity of parameters."""
+        fractions = [
+            self.train_fraction, self.valid_fraction, self.test_fraction
+        ]
+        assert all(0. <= fraction <= 1. for fraction in fractions)
+        assert sum(fractions) <= 1
 
 
 class TrajectorySliceDataset(Dataset):
-    """Dataset of trajectory slices for training.
+    r"""Dataset of trajectory slices for training.
 
-    Given a list of trajectories
+    Given a list of trajectories and a :py:class:`TrajectorySliceConfig`\ ,
+    generates sets of (previous states, future states) transition pairs to be
+    used with the training loss of an experiment.
 
+    Extends :py:class:`torch.utils.data.Dataset` type in order to be managed
+    in the training process with a :py:class:`torch.utils.data.DataLoader`\ .
     """
-    in_slices: List[Tensor]
-    out_slices: List[Tensor]
+    config: TrajectorySliceConfig
+    """Slice configuration describing durations and start index."""
+    previous_states_slices: List[Tensor]
+    r"""Initial conditions of duration ``self.config.t_history`` ."""
+    future_states_slices: List[Tensor]
+    r"""Future targets of duration ``self.config.t_prediction`` ."""
 
-    def __init__(self,
-                 trajectories: List[Tensor],
-                 t_skip: int = 0,
-                 t_history: int = 1,
-                 t_prediction: int = 1):
-        """Initialization:
+    def __init__(self, config: TrajectorySliceConfig):
+        """
+        Args:
+            config: configuration object for slice dataset.
+        """
+        self.config = config
+        self.previous_states_slices = []  # type: List[Tensor]
+        self.future_states_slices = []  # type: List[Tensor]
+
+    def add_slices_from_trajectory(self, trajectory: Tensor) -> None:
+        """Incorporate trajectory into dataset as a set of slices.
 
         Args:
-            trajectories: test
-            t_skip:
-            t_history:
-            t_prediction:
+            trajectory: ``(T, *)`` state trajectory.
         """
-        assert t_skip + 1 >= t_history
-        self.t_skip = t_skip
-        self.t_history = t_history
-        self.t_prediction = t_prediction
-        self.in_slices = []  # type: List[Tensor]
-        self.out_slices = []  # type: List[Tensor]
-        for trajectory in trajectories:
-            self.add_sliced_trajectory(trajectory)
-
-    def add_sliced_trajectory(
-            self, traj: Tensor) -> Tuple[List[Tensor], List[Tensor]]:
-        traj_len = traj.shape[0]
-        first = self.t_skip
-        last = traj_len - self.t_prediction
-        in_window = self.t_history
-        out_window = self.t_prediction
-        assert first <= last
-        for i in range(first, last):
-            self.in_slices.append(traj[(i + 1 - in_window):(i + 1), :])
-            self.out_slices.append(traj[(i + 1):(i + 1 + out_window), :])
+        trajectory_duration = trajectory.shape[0]
+        first_time_index = self.config.t_skip
+        last_time_index = trajectory_duration - self.config.t_prediction
+        previous_states_length = self.config.t_history
+        future_states_length = self.config.t_prediction
+        assert first_time_index <= last_time_index
+        for time in range(first_time_index, last_time_index):
+            self.previous_states_slices.append(
+                trajectory[(time + 1 - previous_states_length):(time + 1), :])
+            self.future_states_slices.append(
+                trajectory[(time + 1):(time + 1 + future_states_length), :])
 
     def __len__(self) -> int:
-        return len(self.in_slices)
+        """Length of dataset as number of total slice pairs."""
+        return len(self.previous_states_slices)
 
     def __getitem__(self, idx) -> Tuple[Tensor, Tensor]:
-        return self.in_slices[idx], self.out_slices[idx]
+        """Retrieve slice pair at index."""
+        return self.previous_states_slices[idx], self.future_states_slices[idx]
 
 
 @dataclass
 class TrajectorySet:
+    """Dataclass encapsulating the various transforms of a set of
+    trajectories that are used during the training and evaluation process,
+    including:
+
+        * Slices for training;
+        * Entire trajectories for evaluation; and
+        * Indices associated with on-disk location for experiment resumption.
+    """
     slices: TrajectorySliceDataset
-    trajectories: List[Tensor]
+    """Trajectories rendered as a dataset of time slices."""
+    trajectories: List[Tensor] = field(default_factory=lambda: [])
+    """Trajectories in their raw format."""
+    indices: Tensor = field(default_factory=lambda: Tensor([]).long())
+    """Indices associated with on-disk filenames."""
+
+    def __post_init__(self):
+        """Validate correspondence between trajectories and indices."""
+        assert self.indices.nelement() == len(self.trajectories)
+        # assure all indices are unique
+        assert self.indices.unique().nelement() == self.indices.nelement()
+
+    def add_trajectories(self, trajectory_list: List[Tensor], indices: Tensor) \
+            -> None:
+        """Add new subset of trajectories to set.
+
+        Args:
+            trajectory_list: List of new ``(T, *)`` state trajectories.
+            indices: indices associated with on-disk filenames.
+        """
+        self.trajectories.extend(trajectory_list)
+        for trajectory in trajectory_list:
+            self.slices.add_slices_from_trajectory(trajectory)
+        # pylint: disable=no-member
+        self.indices = torch.cat([self.indices, indices])
 
 
-class SystemDataManager:
-    system: System
-    storage: str
+class ExperimentDataManager:
+    r"""Management object for maintaining training, validation, and testing
+    data for an experiment.
+
+    Loads trajectories stored in standard location associated with provided
+    storage directory; splits into train/valid/test sets; and instantiates
+    transformations for each set of data as a :py:class:`TrajectorySet`\ .
+    """
+    trajectory_dir: str
     config: DataConfig
     train_set: TrajectorySet
     valid_set: TrajectorySet
     test_set: TrajectorySet
-    n_on_disk: int
+    n_sorted: int
 
-    def __init__(self, system: System, storage: str, config: DataConfig) -> \
-            None:
-        self.system = system
-        self.storage = storage
-        self.config = config
-
-        # ensure only one data source
-        do_generate = config.generation_config is not None
-        do_import = config.import_directory is not None
-        do_dynamics = config.dynamic_updates_from is not None
-        assert (int(do_generate) + int(do_import) + int(do_dynamics)) == 1
-        if do_generate:
-            self.generate()
-
-        elif do_import:
-            file_utils.import_data_to_storage(self.storage,
-                                              config.import_directory)
-
+    def __init__(self, storage: str, config: DataConfig,
+                 initial_split: Optional[Tuple[Tensor, Tensor, Tensor]] = None,
+                 use_ground_truth: bool = False) -> None:
+        """s
+        Args:
+            storage: Storage directory to source trajectories from.
+            config: Configuration object.
+            initial_split: Initial apportionment of trajectories into (train,
+              valid, test) sets.
+            use_ground_truth: Whether trajectories should be sourced from
+              ground-truth or learning data.
+        """
+        if use_ground_truth:
+            self.trajectory_dir = file_utils.ground_truth_data_dir(storage)
         else:
-            print("Waiting for minimum trajectory count...")
-            n_on_disk = file_utils.get_trajectory_count(self.storage)
-            while n_on_disk < config.dynamic_updates_from:
-                n_on_disk = file_utils.get_trajectory_count(self.storage)
-                time.sleep(1)
-            print("Minimum trajectory count reached!")
+            self.trajectory_dir = file_utils.learning_data_dir(storage)
+        self.config = config
+        self.train_set = self.make_empty_trajectory_set()
+        self.valid_set = self.make_empty_trajectory_set()
+        self.test_set = self.make_empty_trajectory_set()
+        self.n_sorted = 0
+        if initial_split:
+            self.extend_trajectory_sets(initial_split)
 
-        self.n_on_disk = file_utils.get_trajectory_count(self.storage)
-
-        self.get_trajectory_split()
-
-    def generate_trajectory_set(self, N: int, T: int) -> List[Tensor]:
-        assert N >= 0
-        assert T >= 1
-        config = self.config
-        assert config.generation_config is not None
-        generation_config = config.generation_config
-        system = self.system
-        starting_state = generation_config.x_0
-        system.set_state_sampler(
-            generation_config.sampler_type(system.space,
-                                           generation_config.sampler_ranges,
-                                           x_0=starting_state))
-
-        trajectories = []
-        for i in range(N):
-            xtraj, carry = system.sample_trajectory(T)
-            trajectories.append(xtraj)
-        return self.noised_trajectories(trajectories)
-
-    def make_trajectory_set(self, trajectories: List[Tensor]) -> TrajectorySet:
-        config = self.config
-        slice_dataset = TrajectorySliceDataset(trajectories, config.t_skip,
-                                               config.t_history,
-                                               config.t_prediction)
-        return TrajectorySet(slices=slice_dataset, trajectories=trajectories)
-
-    def generate(self) -> None:
-        config = self.config
-        assert config.generation_config is not None
-        traj_len = config.generation_config.traj_len
-        n_pop = config.generation_config.n_pop
-        n_generated = file_utils.get_trajectory_count(self.storage)
-        n_set = 30
-        while n_generated < n_pop:
-            traj_i = self.generate_trajectory_set(n_set, traj_len)
-            n_generated = file_utils.get_trajectory_count(self.storage)
-            if n_generated == n_pop:
-                break
-            n_set = min(n_set, n_pop - n_generated)
-            for i in range(n_set):
-                torch.save(
-                    traj_i[i],
-                    file_utils.trajectory_file(self.storage, n_generated + i))
-
-    def get_trajectories(self, N_begin: int, N_end: int,
-                         N_requested: int) -> List[Tensor]:
-        n_on_disk = self.n_on_disk
-        assert n_on_disk >= N_end
-        trajectory_order = torch.randperm(N_end - N_begin) + N_begin
-        selection = trajectory_order[:N_requested]
-
-        data = [
-            torch.load(file_utils.trajectory_file(self.storage, i))
-            for i in selection
-        ]
-        return data
-
-    def noised_trajectories(self, traj_set: List[Tensor]):
-        config = self.config
-        assert config.generation_config is not None
-        generation_config = config.generation_config
-        noiser = generation_config.noiser_type(self.system.space)
-        noised_trajectories = []
-        for traj in traj_set:
-            static_disturbed = noiser.noise(traj,
-                                            generation_config.static_noise,
-                                            independent=False)
-            dynamic_disturbed = noiser.noise(static_disturbed,
-                                             generation_config.dynamic_noise)
-            dynamic_disturbed = self.system.space.project_derivative(
-                dynamic_disturbed, config.dt)
-            noised_trajectories.append(dynamic_disturbed)
-        return noised_trajectories
-
-    def get_trajectory_split(
+    @property
+    def _trajectory_sets(
             self) -> Tuple[TrajectorySet, TrajectorySet, TrajectorySet]:
-
-        config = self.config
-        n_on_disk = self.n_on_disk
-        if not hasattr(self, 'train_set'):
-            N_train = round(n_on_disk * config.train_fraction)
-            N_valid = round(n_on_disk * config.valid_fraction)
-            N_test = round(n_on_disk * config.test_fraction)
-            N_test = min(N_test, n_on_disk - N_train - N_valid)
-            N_tot = sum([N_train, N_test, N_valid])
-
-            traj_set = self.get_trajectories(0, n_on_disk, N_tot)
-
-            train_traj = traj_set[:N_train]
-            traj_set = traj_set[N_train:]
-
-            valid_traj = traj_set[:N_valid]
-            test_traj = traj_set[N_valid:]
-
-            self.train_set = self.make_trajectory_set(train_traj)
-            self.valid_set = self.make_trajectory_set(valid_traj)
-            self.test_set = self.make_trajectory_set(test_traj)
-        elif config.dynamic_updates_from:
-            # update trajectory sets
-            n_on_disk_new = file_utils.get_trajectory_count(self.storage)
-            if n_on_disk_new != n_on_disk:
-                new_count = n_on_disk_new - n_on_disk
-                self.n_on_disk = n_on_disk_new
-                N_train = round(new_count * config.train_fraction)
-                N_valid = round(new_count * config.valid_fraction)
-                N_test = round(new_count * config.test_fraction)
-                N_tot = sum([N_train, N_test, N_valid])
-                new_traj_set = self.get_trajectories(n_on_disk, n_on_disk_new,
-                                                     N_tot)
-                train_traj = new_traj_set[:N_train]
-                new_traj_set = new_traj_set[N_train:]
-
-                valid_traj = new_traj_set[:N_valid]
-                test_traj = new_traj_set[N_valid:]
-
-                sets = (self.train_set, self.valid_set, self.test_set)
-                trajectory_lists = (train_traj, valid_traj, test_traj)
-                for set, trajectory_list in zip(sets, trajectory_lists):
-                    set.trajectories.extend(trajectory_list)
-                    for trajectory in trajectory_list:
-                        set.slices.add_sliced_trajectory(trajectory)
+        """getter for tuple of (train, valid, test) set."""
         return self.train_set, self.valid_set, self.test_set
+
+    def trajectory_set_indices(self) -> Tuple[Tensor, Tensor, Tensor]:
+        """The sets of indices associated with the (train, valid,
+        test) trajectories."""
+        index_lists = [
+            trajectory_set.indices for trajectory_set in self._trajectory_sets
+        ]
+        return cast(Tuple[Tensor, Tensor, Tensor], tuple(index_lists))
+
+    def make_empty_trajectory_set(self) -> TrajectorySet:
+        r"""Instantiates an empty :py:class:`TrajectorySet` associated with
+        the time slice configuration contained in :py:attr:`config`\ ."""
+        slice_dataset = TrajectorySliceDataset(self.config.slice_config)
+        return TrajectorySet(slices=slice_dataset)
+
+    def extend_trajectory_sets(
+            self, index_lists: Tuple[Tensor, Tensor, Tensor]) -> None:
+        """Supplement each of (train, valid, test) trajectory sets with
+        provided trajectories, listed by their on-disk indices.
+
+        Args:
+            index_lists: Lists of trajectory indices for each set.
+        """
+        for trajectory_set, trajectory_indices in zip(self._trajectory_sets,
+                                                      index_lists):
+            trajectories = [
+                torch.load(
+                    file_utils.trajectory_file(self.trajectory_dir,
+                                               trajectory_index))
+                for trajectory_index in trajectory_indices
+            ]
+            trajectory_set.add_trajectories(trajectories, trajectory_indices)
+            self.n_sorted += trajectory_indices.nelement()
+
+    def get_updated_trajectory_sets(
+            self) -> Tuple[TrajectorySet, TrajectorySet, TrajectorySet]:
+        """Returns an up-to-date partition of trajectories on disk.
+
+        Checks if some trajectories on disk have yet to be sorted,
+        and supplements the (train, valid, test) sets with these additional
+        trajectories before returning the updated sets.
+
+        Returns:
+            Training set.
+            Validation set.
+            Test set.
+        """
+        config = self.config
+        n_on_disk = file_utils.get_trajectory_count(self.trajectory_dir)
+        if n_on_disk != self.n_sorted:
+            n_unsorted = n_on_disk - self.n_sorted
+            n_train = round(n_unsorted * config.train_fraction)
+            n_valid = round(n_unsorted * config.valid_fraction)
+            n_remaining = n_unsorted - n_valid - n_train
+            n_test = min(n_remaining, round(n_unsorted * config.test_fraction))
+
+            n_requested = n_train + n_valid + n_test
+            assert n_requested <= n_unsorted
+
+            # pylint: disable=no-member
+            trajectory_order = torch.randperm(n_unsorted) + self.n_sorted
+            train_indices = trajectory_order[:n_train]
+            trajectory_order = trajectory_order[n_train:]
+
+            valid_indices = trajectory_order[:n_valid]
+            trajectory_order = trajectory_order[n_valid:]
+            test_indices = trajectory_order[:n_test]
+
+            self.extend_trajectory_sets(
+                (train_indices, valid_indices, test_indices))
+
+        return self._trajectory_sets

--- a/dair_pll/deep_learnable_system.py
+++ b/dair_pll/deep_learnable_system.py
@@ -7,8 +7,8 @@ from torch import Tensor
 from torch.nn import Module
 
 from dair_pll.deep_learnable_model import DeepLearnableModel, DeepRecurrentModel
-from dair_pll.experiment import SystemConfig, \
-    SupervisedLearningExperiment
+from dair_pll.experiment import SupervisedLearningExperiment
+from dair_pll.experiment_config import SystemConfig
 from dair_pll.integrator import Integrator, VelocityIntegrator
 from dair_pll.system import System
 

--- a/dair_pll/drake_experiment.py
+++ b/dair_pll/drake_experiment.py
@@ -11,9 +11,10 @@ from dair_pll import file_utils
 from dair_pll import vis_utils
 from dair_pll.deep_learnable_system import DeepLearnableExperiment
 from dair_pll.drake_system import DrakeSystem
-from dair_pll.experiment import SystemConfig, \
-    SupervisedLearningExperimentConfig, SupervisedLearningExperiment, \
+from dair_pll.experiment import SupervisedLearningExperiment, \
     LEARNED_SYSTEM_NAME, PREDICTION_NAME, TARGET_NAME
+from dair_pll.experiment_config import SystemConfig, \
+    SupervisedLearningExperimentConfig
 from dair_pll.multibody_learnable_system import \
     MultibodyLearnableSystem
 from dair_pll.system import System, SystemSummary

--- a/dair_pll/experiment_config.py
+++ b/dair_pll/experiment_config.py
@@ -56,7 +56,7 @@ class SupervisedLearningExperimentConfig:
     run_wandb: bool = True
     """Whether to run Weights and Biases logging."""
     wandb_project: Optional[str] = None
-    """Optionally, a project to store results under on Weights and Biases."""
+    r"""If :py:attr:`run_wandb`\ , a project to store results under on W&B."""
     full_evaluation_period: int = 1
     """How many epochs should pass between full evaluations."""
     full_evaluation_samples: int = 5
@@ -64,3 +64,8 @@ class SupervisedLearningExperimentConfig:
     update_geometry_in_videos: bool = False
     """Whether to use learned geometry in rollout videos, primarily for
     debugging purposes."""
+
+    def __post_init__(self):
+        """Method to check validity of parameters."""
+        if self.run_wandb:
+            assert self.wandb_project is not None

--- a/dair_pll/experiment_config.py
+++ b/dair_pll/experiment_config.py
@@ -1,0 +1,66 @@
+"""Configuration dataclasses for experiments."""
+from dataclasses import dataclass, field
+from typing import Type, Optional
+
+import torch
+from torch.optim import Optimizer
+
+from dair_pll.dataset_management import DataConfig
+from dair_pll.hyperparameter import Float, Int
+
+
+@dataclass
+class SystemConfig:
+    """Dummy base :py:class:`~dataclasses.dataclass` for parameters for
+    learning dynamics; all inheriting classes are expected to contain all
+    necessary configuration attributes."""
+
+
+@dataclass
+class OptimizerConfig:
+    """:func:`~dataclasses.dataclass` defining setup and usage opf a Pytorch
+    :func:`~torch.optim.Optimizer` for learning."""
+    optimizer: Type[Optimizer] = torch.optim.Adam
+    """Subclass of :py:class:`~torch.optim.Optimizer` to use."""
+    lr: Float = Float(1e-5, log=True)
+    """Learning rate."""
+    wd: Float = Float(4e-5, log=True)
+    """Weight decay."""
+    epochs: int = 10000
+    """Maximum number of epochs to optimize."""
+    patience: int = 30
+    """Number of epochs to wait for early stopping."""
+    batch_size: Int = Int(64, log=True)
+    """Size of batch for an individual gradient step."""
+
+
+@dataclass
+class SupervisedLearningExperimentConfig:
+    """:py:class:`~dataclasses.dataclass` defining setup of a
+    :py:class:`SupervisedLearningExperiment`"""
+    #  pylint: disable=too-many-instance-attributes
+    data_config: DataConfig = field(default_factory=DataConfig)
+    """Configuration for experiment's
+    :py:class:`~dair_pll.system_data_manager.SystemDataManager`."""
+    base_config: SystemConfig = field(default_factory=SystemConfig)
+    """Configuration for experiment's "base" system, from which trajectories
+    are modeled and optionally generated."""
+    learnable_config: SystemConfig = field(default_factory=SystemConfig)
+    """Configuration for system to be learned."""
+    optimizer_config: OptimizerConfig = field(default_factory=OptimizerConfig)
+    """Configuration for experiment's optimization process."""
+    storage: str = './'
+    """Folder for results/data storage. Defaults to working directory."""
+    run_name: str = 'experiment_run'
+    """Unique identifier for experiment run."""
+    run_wandb: bool = True
+    """Whether to run Weights and Biases logging."""
+    wandb_project: Optional[str] = None
+    """Optionally, a project to store results under on Weights and Biases."""
+    full_evaluation_period: int = 1
+    """How many epochs should pass between full evaluations."""
+    full_evaluation_samples: int = 5
+    """How many trajectories to save in full for experiment's summary."""
+    update_geometry_in_videos: bool = False
+    """Whether to use learned geometry in rollout videos, primarily for
+    debugging purposes."""

--- a/dair_pll/file_utils.py
+++ b/dair_pll/file_utils.py
@@ -17,7 +17,7 @@ TRAJ_EXTENSION = '.pt'  # trajectory file
 HYPERPARAMETERS_EXTENSION = '.json'  # hyperparameter set file
 STATS_EXTENSION = '.pkl'  # experiment statistics
 CONFIG_EXTENSION = '.pkl'
-MODEL_EXTENSION = '.pt'
+CHECKPOINT_EXTENSION = '.pt'
 DATA_SUBFOLDER_NAME = 'data'
 RUNS_SUBFOLDER_NAME = 'runs'
 STUDIES_SUBFOLDER_NAME = 'studies'
@@ -27,7 +27,7 @@ TRAJECTORY_GIF_DEFAULT_NAME = 'trajectory.gif'
 FINAL_EVALUATION_NAME = f'statistics{STATS_EXTENSION}'
 HYPERPARAMETERS_FILENAME = f'optimal_hyperparameters{HYPERPARAMETERS_EXTENSION}'
 CONFIG_FILENAME = f'config{CONFIG_EXTENSION}'
-MODEL_FILENAME = f'model{MODEL_EXTENSION}'
+CHECKPOINT_FILENAME = f'checkpoint{CHECKPOINT_EXTENSION}'
 """str: extensions for saved files"""
 
 
@@ -191,7 +191,7 @@ def get_configuration_filename(storage_name: str, run_name: str) -> str:
 
 def get_model_filename(storage_name: str, run_name: str) -> str:
     """Absolute path of experiment configuration."""
-    return path.join(run_dir(storage_name, run_name), MODEL_FILENAME)
+    return path.join(run_dir(storage_name, run_name), CHECKPOINT_FILENAME)
 
 
 def study_dir(storage_name: str, study_name: str) -> str:
@@ -245,7 +245,7 @@ def save_string(
         value: Any,
         save_callback: Optional[Callable[[Any, TextIO], None]] = None) -> None:
     """Save text file."""
-    with open(filename, 'r', encoding='utf8') as file:
+    with open(filename, 'w', encoding='utf8') as file:
         if save_callback:
             save_callback(value, file)
         else:

--- a/dair_pll/file_utils.py
+++ b/dair_pll/file_utils.py
@@ -19,6 +19,8 @@ STATS_EXTENSION = '.pkl'  # experiment statistics
 CONFIG_EXTENSION = '.pkl'
 CHECKPOINT_EXTENSION = '.pt'
 DATA_SUBFOLDER_NAME = 'data'
+LEARNING_DATA_SUBFOLDER_NAME = 'learning'
+GROUND_TRUTH_DATA_SUBFOLDER_NAME = 'ground_truth'
 RUNS_SUBFOLDER_NAME = 'runs'
 STUDIES_SUBFOLDER_NAME = 'studies'
 URDFS_SUBFOLDER_NAME = 'urdfs'
@@ -85,15 +87,20 @@ def import_data_to_storage(storage_name: str, import_data_dir: str) -> None:
         import_data_dir: Directory to import data from.
     """
     # check if data is synchronized already
-    storage_data_dir = data_dir(storage_name)
-    storage_traj_count = get_numeric_file_count(storage_data_dir,
-                                                TRAJ_EXTENSION)
-    data_traj_count = get_numeric_file_count(import_data_dir, TRAJ_EXTENSION)
+    output_directories = [
+        ground_truth_data_dir(storage_name),
+        learning_data_dir(storage_name)
+    ]
+    for output_directory in output_directories:
+        storage_traj_count = get_numeric_file_count(output_directory,
+                                                    TRAJ_EXTENSION)
+        data_traj_count = get_numeric_file_count(import_data_dir,
+                                                 TRAJ_EXTENSION)
 
-    # overwrite in case of any discrepancies
-    if storage_traj_count != data_traj_count:
-        os.system(f'rm -r {storage_data_dir}')
-        os.system(f'cp -r {import_data_dir} {storage_data_dir}')
+        # overwrite in case of any discrepancies
+        if storage_traj_count != data_traj_count:
+            os.system(f'rm -r {output_directory}')
+            os.system(f'cp -r {import_data_dir} {output_directory}')
 
 
 def storage_dir(storage_name: str) -> str:
@@ -103,9 +110,22 @@ def storage_dir(storage_name: str) -> str:
 
 
 def data_dir(storage_name: str) -> str:
-    """Absolute path of training/validation/test trajectories directory"""
+    """Absolute path of data folder."""
     return assure_created(
         path.join(storage_dir(storage_name), DATA_SUBFOLDER_NAME))
+
+
+def learning_data_dir(storage_name: str) -> str:
+    """Absolute path of folder for data preprocessed for
+    training/validation."""
+    return assure_created(
+        path.join(data_dir(storage_name), LEARNING_DATA_SUBFOLDER_NAME))
+
+
+def ground_truth_data_dir(storage_name: str) -> str:
+    """Absolute path of folder for raw unprocessed trajectories."""
+    return assure_created(
+        path.join(data_dir(storage_name), GROUND_TRUTH_DATA_SUBFOLDER_NAME))
 
 
 def all_runs_dir(storage_name: str) -> str:
@@ -145,14 +165,14 @@ def get_numeric_file_count(directory: str,
     return len(glob.glob(path.join(directory, './[0-9]*' + extension)))
 
 
-def get_trajectory_count(storage_name: str):
-    """Count number of trajectories on disc in storage directory"""
-    return get_numeric_file_count(data_dir(storage_name), TRAJ_EXTENSION)
+def get_trajectory_count(trajectory_dir: str):
+    """Count number of trajectories on disk in given directory."""
+    return get_numeric_file_count(trajectory_dir, TRAJ_EXTENSION)
 
 
-def trajectory_file(storage_name: str, num_trajectory: int) -> str:
+def trajectory_file(trajectory_dir: str, num_trajectory: int) -> str:
     """Absolute path of specific trajectory in storage"""
-    return path.join(data_dir(storage_name),
+    return path.join(trajectory_dir,
                      f'{num_trajectory}{TRAJ_EXTENSION}')
 
 

--- a/dair_pll/file_utils.py
+++ b/dair_pll/file_utils.py
@@ -5,13 +5,19 @@ training runs. The functions herein can be used to return absolute paths of and
 summary information about the content of this directory.
 """
 import glob
+import json
 import os
+import pickle
 from os import path
-from typing import List, Callable
+from typing import List, Callable, BinaryIO, Any, TextIO, Optional
+
+from dair_pll.experiment_config import SupervisedLearningExperimentConfig
 
 TRAJ_EXTENSION = '.pt'  # trajectory file
 HYPERPARAMETERS_EXTENSION = '.json'  # hyperparameter set file
 STATS_EXTENSION = '.pkl'  # experiment statistics
+CONFIG_EXTENSION = '.pkl'
+MODEL_EXTENSION = '.pt'
 DATA_SUBFOLDER_NAME = 'data'
 RUNS_SUBFOLDER_NAME = 'runs'
 STUDIES_SUBFOLDER_NAME = 'studies'
@@ -20,6 +26,8 @@ WANDB_SUBFOLDER_NAME = 'wandb'
 TRAJECTORY_GIF_DEFAULT_NAME = 'trajectory.gif'
 FINAL_EVALUATION_NAME = f'statistics{STATS_EXTENSION}'
 HYPERPARAMETERS_FILENAME = f'optimal_hyperparameters{HYPERPARAMETERS_EXTENSION}'
+CONFIG_FILENAME = f'config{CONFIG_EXTENSION}'
+MODEL_FILENAME = f'model{MODEL_EXTENSION}'
 """str: extensions for saved files"""
 
 
@@ -62,8 +70,7 @@ def assure_storage_tree_created(storage_name: str) -> None:
     Args:
         storage_name: name of storage directory.
     """
-    storage_directories = [data_dir,
-                           all_runs_dir,
+    storage_directories = [data_dir, all_runs_dir,
                            all_studies_dir]  # type: List[Callable[[str],str]]
 
     for directory in storage_directories:
@@ -97,20 +104,20 @@ def storage_dir(storage_name: str) -> str:
 
 def data_dir(storage_name: str) -> str:
     """Absolute path of training/validation/test trajectories directory"""
-    return assure_created(path.join(storage_dir(storage_name),
-                                    DATA_SUBFOLDER_NAME))
+    return assure_created(
+        path.join(storage_dir(storage_name), DATA_SUBFOLDER_NAME))
 
 
 def all_runs_dir(storage_name: str) -> str:
     """Absolute path of tensorboard storage folder"""
-    return assure_created(path.join(storage_dir(storage_name),
-                                    RUNS_SUBFOLDER_NAME))
+    return assure_created(
+        path.join(storage_dir(storage_name), RUNS_SUBFOLDER_NAME))
 
 
 def all_studies_dir(storage_name: str) -> str:
     """Absolute path of tensorboard storage folder"""
-    return assure_created(path.join(storage_dir(storage_name),
-                                    STUDIES_SUBFOLDER_NAME))
+    return assure_created(
+        path.join(storage_dir(storage_name), STUDIES_SUBFOLDER_NAME))
 
 
 def delete(file_name: str) -> None:
@@ -151,8 +158,7 @@ def trajectory_file(storage_name: str, num_trajectory: int) -> str:
 
 def run_dir(storage_name: str, run_name: str) -> str:
     """Absolute path of run-specific storage folder."""
-    return assure_created(path.join(all_runs_dir(storage_name),
-                                    run_name))
+    return assure_created(path.join(all_runs_dir(storage_name), run_name))
 
 
 def get_trajectory_video_filename(storage_name: str, run_name: str) -> str:
@@ -161,34 +167,36 @@ def get_trajectory_video_filename(storage_name: str, run_name: str) -> str:
                      TRAJECTORY_GIF_DEFAULT_NAME)
 
 
-def get_final_evaluation_filename(storage_name: str, run_name: str) -> str:
-    """Return the filepath of the temporary rollout video gif."""
-    return path.join(run_dir(storage_name, run_name),
-                     FINAL_EVALUATION_NAME)
-
-
 def get_learned_urdf_dir(storage_name: str, run_name: str) -> str:
     """Absolute path of learned model URDF storage directory."""
-    return assure_created(path.join(run_dir(storage_name, run_name),
-                                    URDFS_SUBFOLDER_NAME))
+    return assure_created(
+        path.join(run_dir(storage_name, run_name), URDFS_SUBFOLDER_NAME))
 
 
 def wandb_dir(storage_name: str, run_name: str) -> str:
     """Absolute path of tensorboard storage folder"""
-    return assure_created(path.join(run_dir(storage_name, run_name),
-                                    WANDB_SUBFOLDER_NAME))
+    return assure_created(
+        path.join(run_dir(storage_name, run_name), WANDB_SUBFOLDER_NAME))
 
 
 def get_evaluation_filename(storage_name: str, run_name: str) -> str:
     """Absolute path of experiment run statistics file."""
-    return path.join(run_dir(storage_name, run_name),
-                     FINAL_EVALUATION_NAME)
+    return path.join(run_dir(storage_name, run_name), FINAL_EVALUATION_NAME)
+
+
+def get_configuration_filename(storage_name: str, run_name: str) -> str:
+    """Absolute path of experiment configuration."""
+    return path.join(run_dir(storage_name, run_name), CONFIG_FILENAME)
+
+
+def get_model_filename(storage_name: str, run_name: str) -> str:
+    """Absolute path of experiment configuration."""
+    return path.join(run_dir(storage_name, run_name), MODEL_FILENAME)
 
 
 def study_dir(storage_name: str, study_name: str) -> str:
     """Absolute path of study-specific storage folder."""
-    return assure_created(path.join(all_studies_dir(storage_name),
-                                    study_name))
+    return assure_created(path.join(all_studies_dir(storage_name), study_name))
 
 
 def hyperparameter_opt_run_name(study_name: str, trial_number: int) -> str:
@@ -205,3 +213,84 @@ def get_hyperparameter_filename(storage_name: str, study_name: str) -> str:
     """Absolute path of optimized hyperparameters for a study"""
     return path.join(study_dir(storage_name, study_name),
                      HYPERPARAMETERS_FILENAME)
+
+
+def load_binary(filename: str, load_callback: Callable[[BinaryIO], Any]) -> Any:
+    """Load binary file"""
+    with open(filename, 'rb') as file:
+        value = load_callback(file)
+    return value
+
+
+def load_string(filename: str,
+                load_callback: Optional[Callable[[TextIO], Any]] = None) -> Any:
+    """Load text file"""
+    with open(filename, 'r', encoding='utf8') as file:
+        if load_callback:
+            value = load_callback(file)
+        else:
+            value = file.read()
+    return value
+
+
+def save_binary(filename: str, value: Any,
+                save_callback: Callable[[Any, BinaryIO], None]) -> None:
+    """Save binary file."""
+    with open(filename, 'wb') as file:
+        save_callback(value, file)
+
+
+def save_string(
+        filename: str,
+        value: Any,
+        save_callback: Optional[Callable[[Any, TextIO], None]] = None) -> None:
+    """Save text file."""
+    with open(filename, 'r', encoding='utf8') as file:
+        if save_callback:
+            save_callback(value, file)
+        else:
+            assert isinstance(value, str)
+            file.write(value)
+
+
+def load_configuration(storage_name: str, run_name: str) -> \
+        SupervisedLearningExperimentConfig:
+    """Load configuration file."""
+    configuration_filename = get_configuration_filename(storage_name, run_name)
+    configuration = load_binary(configuration_filename, pickle.load)
+    assert isinstance(configuration, SupervisedLearningExperimentConfig)
+    return configuration
+
+
+def save_configuration(storage_name: str, run_name: str,
+                       config: SupervisedLearningExperimentConfig) -> None:
+    """Save configuration file."""
+    configuration_filename = get_configuration_filename(storage_name, run_name)
+    save_binary(configuration_filename, config, pickle.dump)
+
+
+def load_evaluation(storage_name: str, run_name: str) -> Any:
+    """Load evaluation file."""
+    evaluation_filename = get_evaluation_filename(storage_name, run_name)
+    return load_binary(evaluation_filename, pickle.load)
+
+
+def save_evaluation(storage_name: str, run_name: str, evaluation: Any) -> None:
+    """Save evaluation file."""
+    evaluation_filename = get_evaluation_filename(storage_name, run_name)
+    save_binary(evaluation_filename, evaluation, pickle.dump)
+
+
+def load_hyperparameters(storage_name: str, study_name: str) -> Any:
+    """Load hyperparameter file."""
+    hyperparameter_filename = get_hyperparameter_filename(
+        storage_name, study_name)
+    return load_string(hyperparameter_filename, json.load)
+
+
+def save_hyperparameters(storage_name: str, study_name: str,
+                         hyperparameters: Any) -> None:
+    """Save hyperparameter file."""
+    hyperparameter_filename = get_hyperparameter_filename(
+        storage_name, study_name)
+    save_string(hyperparameter_filename, hyperparameters, json.dump)

--- a/dair_pll/mujoco_experiment.py
+++ b/dair_pll/mujoco_experiment.py
@@ -7,8 +7,9 @@ import torch
 
 from dair_pll.deep_learnable_system import \
     DeepLearnableSystemConfig, DeepLearnableExperiment
-from dair_pll.experiment import SupervisedLearningExperimentConfig, \
-    OptimizerConfig, DataConfig, TrajectorySliceDataset
+from dair_pll.experiment import DataConfig, TrajectorySliceDataset
+from dair_pll.experiment_config import OptimizerConfig, \
+    SupervisedLearningExperimentConfig
 from dair_pll.mujoco_system import MuJoCoSystem, MuJoCoUKFSystem
 
 

--- a/dair_pll/multibody_learnable_system.py
+++ b/dair_pll/multibody_learnable_system.py
@@ -29,7 +29,7 @@ import torch
 from sappy import SAPSolver  # type: ignore
 from torch import Tensor
 
-from dair_pll import urdf_utils, tensor_utils
+from dair_pll import urdf_utils, tensor_utils, file_utils
 from dair_pll.drake_system import DrakeSystem
 from dair_pll.integrator import VelocityIntegrator
 from dair_pll.multibody_terms import MultibodyTerms
@@ -96,8 +96,7 @@ class MultibodyLearnableSystem(System):
         for urdf_name, new_urdf_string in new_urdf_strings.items():
             old_urdf_filename = path.basename(old_urdfs[urdf_name])
             new_urdf_path = path.join(self.output_urdfs_dir, old_urdf_filename)
-            with open(new_urdf_path, 'w', encoding="utf8") as new_urdf_file:
-                new_urdf_file.write(new_urdf_string)
+            file_utils.save_string(new_urdf_path, new_urdf_string)
             new_urdfs[urdf_name] = new_urdf_path
 
         return new_urdfs

--- a/dair_pll/study.py
+++ b/dair_pll/study.py
@@ -68,7 +68,7 @@ class Study:
         trial_experiment_config.run_name = run_name
 
         experiment = config.experiment_type(trial_experiment_config)
-        _, best_valid_loss, _, _ = experiment.train(epoch_callback)
+        _, best_valid_loss, _ = experiment.train(epoch_callback)
         return best_valid_loss.item()
 
     def study(self) -> None:

--- a/dair_pll/study.py
+++ b/dair_pll/study.py
@@ -68,7 +68,7 @@ class Study:
         trial_experiment_config.run_name = run_name
 
         experiment = config.experiment_type(trial_experiment_config)
-        _, best_valid_loss, _ = experiment.train(epoch_callback)
+        _, best_valid_loss, _, _ = experiment.train(epoch_callback)
         return best_valid_loss.item()
 
     def study(self) -> None:
@@ -96,6 +96,8 @@ class Study:
         sample_experiment_config = copy.deepcopy(
             self.config.default_experiment_config)
         hyperparameter.load_suggestion(sample_experiment_config, hps)
+        # TODO: reengineer training fractions to have concrete values as
+        #  options.
         sample_experiment_config.data_config.n_train = N_train
 
         sample_experiment_config.run_name = file_utils.sweep_run_name(

--- a/dair_pll/wandb_manager.py
+++ b/dair_pll/wandb_manager.py
@@ -1,4 +1,6 @@
 """Interface for logging training progress to Weights and Biases."""
+import time
+from dataclasses import dataclass
 from typing import Dict, Tuple, Optional, Any
 
 import numpy as np
@@ -6,6 +8,9 @@ import wandb
 
 from dair_pll.hyperparameter import hyperparameter_values
 from dair_pll.system import MeshSummary
+
+WANDB_ALLOW = "allow"
+WANDB_NEVER = "never"
 
 
 def _write_scalars(epoch: int, scalars: Dict[str, float]) -> None:
@@ -32,6 +37,7 @@ def _write_meshes(epoch: int, meshes: Dict[str, MeshSummary]) -> None:
     wandb.log(wandb_meshes, step=epoch)
 
 
+@dataclass
 class WeightsAndBiasesManager:
     """Manages logging of the training process.
 
@@ -42,34 +48,44 @@ class WeightsAndBiasesManager:
     """Unique name for Weights and Biases experiment run."""
     directory: str
     """Absolute path to store metadata."""
-    project_name: Optional[str]
+    project_name: str
     """Unique name for W&B project, analogous to a ``dair_pll`` experiment."""
+    resume_from_id: Optional[str] = None
+    """Allow W&B to resume a run ID if provided."""
 
-    def __init__(self, run_name: str, directory: str,
-                 project_name: Optional[str]):
-        self.run_name = run_name
-        self.directory = directory
-        self.project_name = project_name
+    def _setup_wandb_run_id(self) -> str:
+        """Generates unique run ID for Weights and Biases by concatenating
+        the run name and a timestamp. If resumption is allowed, returns the
+        saved run ID."""
+        if self.resume_from_id is not None:
+            return self.resume_from_id
 
-    def launch(self) -> None:
+        timestamp = str(time.time_ns() // 1000)
+
+        return f"{self.run_name}_{timestamp}"
+
+    def launch(self) -> str:
         r"""Launches experiment run on Weights & Biases.
 
-        Todo:
-            Because we manage local storage separate from remote,
-            it's possible that a crash at just the wrong time could cause
-            ``dair_pll`` to think it's resuming a run, while W&B never
-            got notified of the run. To handle this discrepancy, we set
-            ``resume="allow"``\ , which may cause unexpected behavior if a
-            new run is given the same name as an old run on W&B. Some way of
-            rectifying this behavior, such as moving the resume detection
-            fully to W&B, should eventually be implemented.
+        As Weight & Biases does not allow for the creation of a run with the
+        same ID as a deleted run, this method will delete any existing runs
+        associated with the given run name if resumptions is not allowed.
+        See :py:meth:`_setup_wandb_run_id` for more details.
+
+        Returns:
+            The run ID of the launched run.
         """
+        resuming = self.resume_from_id is not None
+        wandb_run_id = self._setup_wandb_run_id()
+
         wandb.init(project=self.project_name,
                    dir=self.directory,
                    name=self.run_name,
-                   id=self.run_name,
+                   id=wandb_run_id,
                    config={},
-                   resume="allow")
+                   resume=WANDB_ALLOW if resuming else WANDB_NEVER)
+
+        return wandb_run_id
 
     @staticmethod
     def log_config(config: Any):

--- a/dair_pll/wandb_manager.py
+++ b/dair_pll/wandb_manager.py
@@ -52,12 +52,24 @@ class WeightsAndBiasesManager:
         self.project_name = project_name
 
     def launch(self) -> None:
-        """Launches experiment run on Weights & Biases."""
+        r"""Launches experiment run on Weights & Biases.
+
+        Todo:
+            Because we manage local storage separate from remote,
+            it's possible that a crash at just the wrong time could cause
+            ``dair_pll`` to think it's resuming a run, while W&B never
+            got notified of the run. To handle this discrepancy, we set
+            ``resume="allow"``\ , which may cause unexpected behavior if a
+            new run is given the same name as an old run on W&B. Some way of
+            rectifying this behavior, such as moving the resume detection
+            fully to W&B, should eventually be implemented.
+        """
         wandb.init(project=self.project_name,
                    dir=self.directory,
                    name=self.run_name,
                    id=self.run_name,
-                   config={})
+                   config={},
+                   resume="allow")
 
     @staticmethod
     def log_config(config: Any):

--- a/dair_pll/wandb_manager.py
+++ b/dair_pll/wandb_manager.py
@@ -45,13 +45,13 @@ class WeightsAndBiasesManager:
     at https://wandb.ai .
     """
     run_name: str
-    """Unique name for Weights and Biases experiment run."""
+    """Display name for Weights and Biases experiment run."""
     directory: str
     """Absolute path to store metadata."""
     project_name: str
     """Unique name for W&B project, analogous to a ``dair_pll`` experiment."""
     resume_from_id: Optional[str] = None
-    """Allow W&B to resume a run ID if provided."""
+    """Allow W&B to resume a unique run ID if provided."""
 
     def _setup_wandb_run_id(self) -> str:
         """Generates unique run ID for Weights and Biases by concatenating
@@ -66,11 +66,6 @@ class WeightsAndBiasesManager:
 
     def launch(self) -> str:
         r"""Launches experiment run on Weights & Biases.
-
-        As Weight & Biases does not allow for the creation of a run with the
-        same ID as a deleted run, this method will delete any existing runs
-        associated with the given run name if resumptions is not allowed.
-        See :py:meth:`_setup_wandb_run_id` for more details.
 
         Returns:
             The run ID of the launched run.

--- a/examples/contactnets_simple.py
+++ b/examples/contactnets_simple.py
@@ -70,7 +70,7 @@ SAMPLER_RANGES = {
     CUBE_SYSTEM: CUBE_SAMPLER_RANGE,
     ELBOW_SYSTEM: ELBOW_SAMPLER_RANGE
 }
-TRAJECTORY_DURATIONS = {CUBE_SYSTEM: 80, ELBOW_SYSTEM: 120}
+TRAJECTORY_LENGTHS = {CUBE_SYSTEM: 80, ELBOW_SYSTEM: 120}
 
 # Training data configuration.
 T_PREDICTION = 1
@@ -86,6 +86,8 @@ EPOCHS = 500
 PATIENCE = EPOCHS
 BATCH_SIZE = 256
 
+WANDB_PROJECT = 'dair_pll-examples'
+
 
 def main(run_name: str = "",
          system: str = CUBE_SYSTEM,
@@ -94,7 +96,6 @@ def main(run_name: str = "",
          box: bool = True,
          regenerate: bool = False,
          clear_data: bool = False):
-    # pylint: disable=too-many-arguments
     """Execute ContactNets basic example on a system.
 
     Args:
@@ -106,7 +107,7 @@ def main(run_name: str = "",
         regenerate: Whether save updated URDF's each epoch.
         clear_data: Whether to clear storage folder before running.
     """
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-arguments
 
     # First step, clear out data on disk for a fresh start.
     simulation = source == SIM_SOURCE
@@ -169,6 +170,8 @@ def main(run_name: str = "",
         data_config=data_config,
         full_evaluation_period=EPOCHS if dynamic else 1,
         visualize_learned_geometry=True,
+        run_wandb=True,
+        wandb_project=WANDB_PROJECT
     )
 
     # Makes experiment.
@@ -184,8 +187,8 @@ def main(run_name: str = "",
             # timestep.
             n_pop=N_POP,
             # How many trajectories to simulate
-            duration=TRAJECTORY_DURATIONS[system],
-            # trajectory duration
+            trajectory_length=TRAJECTORY_LENGTHS[system],
+            # trajectory length
             x_0=x_0,
             # A nominal initial state
             sampler_type=UniformSampler,
@@ -243,7 +246,7 @@ def main(run_name: str = "",
 @click.option('--regenerate/--no-regenerate',
               default=False,
               help="whether save updated URDF's each epoch.")
-@click.option('--clear-data',
+@click.option('--clear-data/--keep-data',
               default=False,
               help="Whether to clear storage folder before running.")
 def main_command(run_name: str, system: str, source: str, contactnets: bool,

--- a/examples/contactnets_simple.py
+++ b/examples/contactnets_simple.py
@@ -10,16 +10,19 @@ import torch
 from torch import Tensor
 
 from dair_pll import file_utils
+from dair_pll.dataset_generation import DataGenerationConfig, \
+    ExperimentDatasetGenerator
 from dair_pll.dataset_management import DataConfig, \
-    DataGenerationConfig
+    TrajectorySliceConfig
 from dair_pll.drake_experiment import \
     DrakeMultibodyLearnableExperiment, DrakeSystemConfig, \
     MultibodyLearnableSystemConfig, MultibodyLosses, \
     DrakeMultibodyLearnableExperimentConfig
 from dair_pll.experiment import default_epoch_callback
 from dair_pll.experiment_config import OptimizerConfig
+from dair_pll.hyperparameter import Float, Int
 from dair_pll.multibody_learnable_system import MultibodyLearnableSystem
-from dair_pll.state_space import UniformSampler
+from dair_pll.state_space import UniformSampler, GaussianWhiteNoiser
 from dair_pll.system import System
 
 CUBE_SYSTEM = 'cube'
@@ -67,10 +70,7 @@ SAMPLER_RANGES = {
     CUBE_SYSTEM: CUBE_SAMPLER_RANGE,
     ELBOW_SYSTEM: ELBOW_SAMPLER_RANGE
 }
-TRAJ_LENS = {CUBE_SYSTEM: 80, ELBOW_SYSTEM: 120}
-
-# dynamic load configuration.
-DYNAMIC_UPDATES_FROM = 4
+TRAJECTORY_DURATIONS = {CUBE_SYSTEM: 80, ELBOW_SYSTEM: 120}
 
 # Training data configuration.
 T_PREDICTION = 1
@@ -110,9 +110,7 @@ def main(run_name: str = "",
 
     # First step, clear out data on disk for a fresh start.
     simulation = source == SIM_SOURCE
-    real = source == REAL_SOURCE
     dynamic = source == DYNAMIC_SOURCE
-
     data_asset = DATA_ASSETS[system]
     # where to store data
     storage_name = os.path.join(os.path.dirname(__file__), 'storage',
@@ -126,12 +124,11 @@ def main(run_name: str = "",
     # Next, build the configuration of the learning experiment.
 
     # Describes the optimizer settings; by default, the optimizer is Adam.
-    optimizer_config = OptimizerConfig()
-    optimizer_config.lr.value = LRS[system]
-    optimizer_config.wd.value = WDS[system]
-    optimizer_config.patience = PATIENCE
-    optimizer_config.epochs = EPOCHS
-    optimizer_config.batch_size.value = BATCH_SIZE
+    optimizer_config = OptimizerConfig(lr=Float(LRS[system]),
+                                       wd=Float(WDS[system]),
+                                       patience=PATIENCE,
+                                       epochs=EPOCHS,
+                                       batch_size=Int(BATCH_SIZE))
 
     # Describes the ground truth system; infers everything from the URDF.
     # This is a configuration for a DrakeSystem, which wraps a Drake
@@ -150,44 +147,17 @@ def main(run_name: str = "",
         MultibodyLosses.PREDICTION_LOSS
     learnable_config = MultibodyLearnableSystemConfig(urdfs=urdfs, loss=loss)
 
-    # Describe data source
-    data_generation_config = None
-    import_directory = None
-    dynamic_updates_from = None
-    x_0 = X_0S[system]
-    if simulation:
-        # For simulation, specify the following:
-        data_generation_config = DataGenerationConfig(
-            n_pop=N_POP,
-            # How many trajectories to simulate
-            x_0=x_0,
-            # A nominal initial state
-            sampler_ranges=SAMPLER_RANGES[system],
-            # How much to vary initial states around ``x_0``
-            sampler_type=UniformSampler,
-            # use uniform distribution to sample ``x_0``
-            static_noise=torch.zeros(x_0.nelement() - 1),
-            # constant-in-time noise distribution (zero in this case)
-            dynamic_noise=torch.zeros(x_0.nelement() - 1),
-            # i.i.d.-in-time noise distribution (zero in this case)
-            traj_len=TRAJ_LENS[system])
-    elif real:
-        # otherwise, specify directory with [T, n_x] tensor files saved as
-        # 0.pt, 1.pt, ...
-        # See :mod:`dair_pll.state_space` for state format.
-        import_directory = file_utils.get_asset(data_asset)
-    else:
-        dynamic_updates_from = DYNAMIC_UPDATES_FROM
+    # how to slice trajectories into training datapoints
+    slice_config = TrajectorySliceConfig(
+        t_prediction=1 if contactnets else T_PREDICTION)
 
     # Describes configuration of the data
     data_config = DataConfig(dt=DT,
                              train_fraction=1.0 if dynamic else 0.5,
                              valid_fraction=0.0 if dynamic else 0.25,
                              test_fraction=0.0 if dynamic else 0.25,
-                             generation_config=data_generation_config,
-                             import_directory=import_directory,
-                             dynamic_updates_from=dynamic_updates_from,
-                             t_prediction=1 if contactnets else T_PREDICTION)
+                             slice_config=slice_config,
+                             update_dynamically=dynamic)
 
     # Combines everything into config for entire experiment.
     experiment_config = DrakeMultibodyLearnableExperimentConfig(
@@ -203,6 +173,46 @@ def main(run_name: str = "",
 
     # Makes experiment.
     experiment = DrakeMultibodyLearnableExperiment(experiment_config)
+
+    # Prepare data.
+    x_0 = X_0S[system]
+    if simulation:
+
+        # For simulation, specify the following:
+        data_generation_config = DataGenerationConfig(
+            dt=DT,
+            # timestep.
+            n_pop=N_POP,
+            # How many trajectories to simulate
+            duration=TRAJECTORY_DURATIONS[system],
+            # trajectory duration
+            x_0=x_0,
+            # A nominal initial state
+            sampler_type=UniformSampler,
+            # use uniform distribution to sample ``x_0``
+            sampler_ranges=SAMPLER_RANGES[system],
+            # How much to vary initial states around ``x_0``
+            noiser_type=GaussianWhiteNoiser,
+            # Distribution of noise in trajectory data (Gaussian).
+            static_noise=torch.zeros(x_0.nelement() - 1),
+            # constant-in-time noise standard deviations (zero in this case)
+            dynamic_noise=torch.zeros(x_0.nelement() - 1),
+            # i.i.d.-in-time noise standard deviations (zero in this case)
+            storage=storage_name
+            # where to store trajectories
+        )
+
+        generator = ExperimentDatasetGenerator(experiment.get_base_system(),
+                                               data_generation_config)
+        generator.generate()
+
+    else:
+        # otherwise, specify directory with [T, n_x] tensor files saved as
+        # 0.pt, 1.pt, ...
+        # See :mod:`dair_pll.state_space` for state format.
+        import_directory = file_utils.get_asset(data_asset)
+        file_utils.import_data_to_storage(storage_name,
+                                          import_data_dir=import_directory)
 
     def regenerate_callback(epoch: int, learned_system: System,
                             train_loss: Tensor,

--- a/examples/contactnets_simple.py
+++ b/examples/contactnets_simple.py
@@ -16,7 +16,8 @@ from dair_pll.drake_experiment import \
     DrakeMultibodyLearnableExperiment, DrakeSystemConfig, \
     MultibodyLearnableSystemConfig, MultibodyLosses, \
     DrakeMultibodyLearnableExperimentConfig
-from dair_pll.experiment import OptimizerConfig, default_epoch_callback
+from dair_pll.experiment import default_epoch_callback
+from dair_pll.experiment_config import OptimizerConfig
 from dair_pll.multibody_learnable_system import MultibodyLearnableSystem
 from dair_pll.state_space import UniformSampler
 from dair_pll.system import System


### PR DESCRIPTION
In #13, @ebianchi noted the value of restarting the often-lengthy training process in an experiment.

This PR implements saving and resuming experiments via the `dair_pll.experiment.TrainingState` dataclass.
Every epoch, `SupervisedLearningExperiment` saves this object to disk at `checkpoint.pt`, which includes

- Train/valid/test split as a list of indices, so training data can be re-apportioned correctly.
- Current learned system state; optimizer state; and epoch number so that the training process can be resumed at the right point.
- Best validation loss, as well as the learned system state that achieved it and the epoch it was achieved on, so that the training process can be properly stopped.

As part of correctly saving data, the functionality for generating simulation data has been separated from the process of loading from disk. This reflects the recent design change to consider multiple experiments as being based around the same dataset. Data generation also now saves both the raw trajectory from the underlying `System` (in `data/ground_truth`) _as well as_ the one with added measurement noise (in `data/learning`). Data generation functionality is now moved to `dataset_generation.py`.

In order to keep the ballooning size of `experiment.py` down, configuration files have been migrated to `experiment_config.py` . For reproducibility, full configurations are also now pickled in `config.pkl` .

File loading and saving has been cleaned up as well, and the current folder structure is:
```
- storage/
  |
  - {storage_name}/
    |
    - data/
      | 
      - ground_truth/
      - learning/
    - runs/
      |
      - {run_name}/
        |
        - urdfs/
        - trajectory.gif
        - statistics.pkl
        - config.pkl
        - checkpoint.pt
        - wandb/
      - {other_run_name}/
        |
        - urdfs/
        - trajectory.gif
        - statistics.pkl
        - config.pkl
        - checkpoint.pt
        - wandb/
    - studies/
      |
      - {study_name}/
        |
        - optimal_hyperparameters.json
```