### PR TITLE
Correct some bugs in training / evaluating final model

### DIFF
--- a/dair_pll/experiment.py
+++ b/dair_pll/experiment.py
@@ -815,7 +815,7 @@ class SupervisedLearningExperiment(ABC):
     def generate_results(
         self,
         epoch_callback: EpochCallbackCallable = default_epoch_callback,
-    ) -> Tuple[Tensor, StatisticsDict]:
+    ) -> Tuple[System, StatisticsDict]:
         r"""Get the final learned model and results/statistics of experiment.
         Along with the model corresponding to best validation loss, this will
         return previously saved results on disk if they already exist, or run

--- a/dair_pll/experiment.py
+++ b/dair_pll/experiment.py
@@ -349,7 +349,6 @@ class SupervisedLearningExperiment(ABC):
         Args:
             data: Training dataset.
             system: System to be trained.
-            optimizer: Optimizer which trains system.
 
         Returns:
             Scalar average training loss observed during evaluation.

--- a/dair_pll/study.py
+++ b/dair_pll/study.py
@@ -109,7 +109,7 @@ class Study:
                      best_valid_loss: float) -> None:
             pass
 
-        experiment.get_results(epoch_cb)
+        experiment.generate_results(epoch_cb)
 
     def is_complete(self, study: optuna.study.Study) -> bool:
         trials = study.trials

--- a/dair_pll/system.py
+++ b/dair_pll/system.py
@@ -112,7 +112,9 @@ class System(ABC, Module):
 
         # If batching is more dimensions than allowed, iterate over outer
         # dimension.
-        if self.max_batch_dim and (x_0.dim() - 2) > self.max_batch_dim:
+        if self.max_batch_dim is not None and \
+            (x_0.dim() - 2) > self.max_batch_dim:
+            
             x_carry_list = [
                 self.simulate(x0i, c0i) for x0i, c0i in zip(x_0, carry_0)
             ]

--- a/examples/contactnets_simple.py
+++ b/examples/contactnets_simple.py
@@ -224,15 +224,16 @@ def main(run_name: str = "",
                                best_valid_loss)
         cast(MultibodyLearnableSystem, learned_system).generate_updated_urdfs()
 
-    # Trains system.
-    print("Training.")
-    experiment.train(
+    # Trains system and saves final results.
+    print(f'\nTraining the model.')
+    learned_system, stats = experiment.generate_results(
         regenerate_callback if regenerate else default_epoch_callback)
 
-    # Store the results of the trained system.
-    print("Evaluating trained model.")
-    experiment.get_results(
-        regenerate_callback if regenerate else default_epoch_callback)
+    # Save the final urdf.
+    print(f'\nSaving the final learned URDF.')
+    learned_system = cast(MultibodyLearnableSystem, learned_system)
+    learned_system.generate_updated_urdfs()
+    print(f'Done!')
 
 
 @click.command()

--- a/examples/contactnets_simple.py
+++ b/examples/contactnets_simple.py
@@ -225,7 +225,13 @@ def main(run_name: str = "",
         cast(MultibodyLearnableSystem, learned_system).generate_updated_urdfs()
 
     # Trains system.
+    print("Training.")
     experiment.train(
+        regenerate_callback if regenerate else default_epoch_callback)
+
+    # Store the results of the trained system.
+    print("Evaluating trained model.")
+    experiment.get_results(
         regenerate_callback if regenerate else default_epoch_callback)
 
 


### PR DESCRIPTION
This PR combines fixes to a couple of minor bugs, plus adds a couple of minor features.  All of these are related to the training process, resuming experiments, and generating results from a completed experiment.

### Bug 1:  Evaluating a system that cannot handle batched data
An assertion statement in `system.py` ([line here](https://github.com/DAIRLab/dair_pll/blob/main/dair_pll/system.py#L115)) intended to check if there was a maximum batch dimension, then to calculate if the provided data exceeded that maximum.  As written, a maximum batch dimension of zero is treated the same as if an unset maximum batch dimension.  The latter should not impose a limit, whereas the former should.

**Fix:**  A quick change to the one line of code:  `if self.max_batch_dim` --> `if self.max_batch_dim is not None`.


### Bug 2:  Training an already finished experiment
When training an experiment which has already finished training (whether by early stopping or by reaching an epoch maximum), `experiment.py` throws an error when it attempts to terminate `train()` because the return argument `training_loss` is not set.

**Fix:** The `training_loss` variable is set before attempting further training via a call to a new `calculate_loss_no_grad_step()` method of the `Experiment` class.  This new method is the same as `train_epoch()` but without any gradient steps, and it is called after setting the model in `eval` mode.


### New feature 1:  Record if training has completed or not
An experiment's `TrainingState` now has a `finished_training` flag, which is `False` until the training process stops due to hitting the maximum epochs or from early stopping.


### New feature 2:  Log model performance with initialized parameters
Before, the model's initialized parameters were never a candidate for the best learned system state.  Now, training an experiment starts with evaluating the model's training and validation losses without taking any gradient steps, initializing the stored best validation loss with this evaluation.