### PR TITLE
Fix mesh export inconsistency

### DIFF
--- a/dair_pll/deep_support_function.py
+++ b/dair_pll/deep_support_function.py
@@ -119,7 +119,7 @@ def extract_mesh(support_function: Callable[[Tensor], Tensor]) -> MeshSummary:
     backwards = backwards.squeeze(0)
     faces[backwards] = faces[backwards].flip(-1)
 
-    return MeshSummary(vertices=support_points, faces=faces)
+    return MeshSummary(vertices=vertices, faces=faces)
 
 
 class HomogeneousICNN(Module):


### PR DESCRIPTION
## Failure Case
Previously, it was possible (albeit unlikely) to generate an inconsistent `MeshSummary` from a learned deep support convex network.  In the `extract_mesh` function, a mesh is generated by querying a multitude of directions and obtaining their corresponding support points.  If any of the returned support points were redundant with one another, the resulting `MeshSummary.vertices` attribute would contain all of these redundant vertices (in `support_points`), but its `faces` attribute would reference indices of a _different_ list of non-redundant vertices (in `vertices`).

## Solution
The simple fix is to store the list of non-redundant vertices in the `MeshSummary.vertices` attribute instead of the original list of possibly redundant vertices.

## Discovery
While it is extremely unlikely to obtain the exact same output from a neural network given different inputs (which is what `extract_mesh` does), we caught this code error when using the same `MeshSummary` generation logic with data in which identical inputs were likely to be present.